### PR TITLE
Add CoverAllCombinations constraint with auto-sizing

### DIFF
--- a/acceptance/test_cover_all_combinations.py
+++ b/acceptance/test_cover_all_combinations.py
@@ -1,0 +1,111 @@
+import pytest
+
+from sweetpea import *
+from sweetpea._internal.constraint import CoverAllCombinations
+
+
+def _stroop(n):
+    """Build a Stroop-style inner block with n colors/words and a derived congruency
+    factor, crossing [congruency, color] (word left free)."""
+    colors = ['red', 'green', 'blue', 'yellow', 'purple'][:n]
+    color = Factor('color', colors)
+    word = Factor('word', colors)
+    congruency = Factor('congruency', [
+        DerivedLevel('con', WithinTrial(lambda c, w: c == w, [color, word])),
+        DerivedLevel('incon', WithinTrial(lambda c, w: c != w, [color, word])),
+    ])
+    inner = CrossBlock([congruency, color, word], [congruency, color], [])
+    return colors, color, word, congruency, inner
+
+
+def _stroop_nest(n, name=None):
+    colors, color, word, congruency, inner = _stroop(n)
+    instance = Factor('instance', ['a', 'b'])
+    outer = CrossBlock([instance], [instance], [])
+    nest = Nest(outer, inner, [CoverAllCombinations(color, word, name=name)])
+    return colors, color, word, nest
+
+
+# ~~~~~~~~~~~~ K computation (isolated) ~~~~~~~~~~~~
+
+@pytest.mark.parametrize('n,expected_k', [(3, 2), (4, 3), (5, 4)])
+def test_required_instances_stroop(n, expected_k):
+    _, color, word, _, inner = _stroop(n)
+    assert CoverAllCombinations(color, word).required_instances(inner) == expected_k
+
+
+def test_required_instances_overlap_below_biggest_group():
+    # Two free factors, neither crossed: slots fully overlap, so K = ceil(4/2) = 2,
+    # not the naive "biggest group" count of 4.
+    colr = Factor('colr', ['red', 'green'])
+    size = Factor('size', ['big', 'small'])
+    task = Factor('task', ['A', 'B'])
+    inner = CrossBlock([task, colr, size], [task], [])
+    assert CoverAllCombinations(colr, size).required_instances(inner) == 2
+
+
+# ~~~~~~~~~~~~ Auto-sizing + coverage (end to end) ~~~~~~~~~~~~
+
+@pytest.mark.parametrize('n,expected_trials', [(3, 12), (4, 32)])
+def test_autosize_trial_count(n, expected_trials):
+    _, _, _, nest = _stroop_nest(n)
+    assert nest.trials_per_sample() == expected_trials
+
+
+@pytest.mark.parametrize('n', [3, 4])
+def test_coverage_holds(n):
+    colors, _, _, nest = _stroop_nest(n)
+    all_pairs = set((c, w) for c in colors for w in colors)
+    exps = synthesize_trials(nest, 5, sampling_strategy=IterateGen)
+    assert exps
+    for e in exps:
+        assert set(zip(e['color'], e['word'])) == all_pairs
+
+
+# ~~~~~~~~~~~~ Validation / error paths ~~~~~~~~~~~~
+
+def test_error_outer_factor_in_scope():
+    _, color, word, _, inner = _stroop(3)
+    instance = Factor('instance', ['a', 'b'])
+    outer = CrossBlock([instance], [instance], [])
+    with pytest.raises(ValueError):
+        Nest(outer, inner, [CoverAllCombinations(instance, color)])
+
+
+def test_error_overlap_sequential():
+    _, color, word, _, inner = _stroop(3)
+    instance = Factor('instance', ['a', 'b'])
+    outer = CrossBlock([instance], [instance], [])
+    with pytest.raises(ValueError):
+        Nest(outer, inner, [Sequential(word), CoverAllCombinations(color, word)])
+
+
+def test_error_overlap_latin_square():
+    _, color, word, _, inner = _stroop(3)
+    instance = Factor('instance', ['a', 'b'])
+    outer = CrossBlock([instance], [instance], [])
+    with pytest.raises(ValueError):
+        Nest(outer, inner, [LatinSquare([color, word], name='P'),
+                            CoverAllCombinations(color, word)])
+
+
+def test_error_not_in_nest():
+    _, color, word, congruency, _ = _stroop(3)
+    with pytest.raises(ValueError):
+        CrossBlock([congruency, color, word], [congruency, color],
+                   [CoverAllCombinations(color, word)])
+
+
+def test_error_weighted_levels():
+    colors = ['red', 'green', 'blue']
+    color = Factor('color', colors)
+    word = Factor('word', [Level('red', 2), Level('green'), Level('blue')])
+    congruency = Factor('congruency', [
+        DerivedLevel('con', WithinTrial(lambda c, w: c == w, [color, word])),
+        DerivedLevel('incon', WithinTrial(lambda c, w: c != w, [color, word])),
+    ])
+    inner = CrossBlock([congruency, color, word], [congruency, color], [])
+    instance = Factor('instance', ['a', 'b'])
+    outer = CrossBlock([instance], [instance], [])
+    with pytest.raises(ValueError):
+        Nest(outer, inner, [CoverAllCombinations(color, word)])

--- a/acceptance/test_cover_all_combinations.py
+++ b/acceptance/test_cover_all_combinations.py
@@ -120,19 +120,20 @@ def test_repeat_autosizes():
         assert _covers_all(e, colors)
 
 
-# ~~~~~~~~~~~~ Coexistence (no construction-time guards) ~~~~~~~~~~~~
+# ~~~~~~~~~~~~ Interaction with other constraints ~~~~~~~~~~~~
 
-def test_coexists_outer_factor_listed():
-    # Listing an outer factor no longer errors; the solver arbitrates.
+def test_outer_factor_listed_constructs():
+    # An outer-block factor in the listed set is not statically sized; the
+    # solver arbitrates. Construction must succeed.
     _, color, word, _, inner = _stroop(3)
     instance = Factor('instance', ['a', 'b'])
     outer = CrossBlock([instance], [instance], [])
     Nest(outer, inner, [CoverAllCombinations(instance, color)])
 
 
-def test_coexists_sequential_shared_factor():
-    # Sequential pins word per position; the positional reconciliation still
-    # finds K=2 (12 trials), and synthesis must produce covering sequences.
+def test_sequential_on_listed_factor():
+    # Sequential pins word per position; positional sizing finds K=2 (12
+    # trials), and synthesis must produce covering sequences.
     colors, color, word, congruency, inner = _stroop(3)
     instance = Factor('instance', ['a', 'b'])
     outer = CrossBlock([instance], [instance], [])
@@ -146,15 +147,15 @@ def test_coexists_sequential_shared_factor():
         assert e['word'] == (colors * 4)[:len(e['word'])]
 
 
-def test_coexists_latin_square_shared_factors():
-    colors, color, word, nest = _stroop_nest(3, [])
-    _, c2, w2, _, inner2 = _stroop(3)
+def test_latin_square_on_listed_factors():
+    # LatinSquare and CoverAllCombinations over the same factors: the solver
+    # satisfies both (LatinSquare's rotations themselves yield full coverage).
+    colors, color, word, congruency, inner = _stroop(3)
     instance = Factor('instance', ['a', 'b'])
     outer = CrossBlock([instance], [instance], [])
-    # Same factors in LatinSquare and CoverAllCombinations: constructs, solver decides.
-    nest2 = Nest(outer, inner2, [LatinSquare([c2, w2], name='P'),
-                                 CoverAllCombinations(c2, w2)])
-    exps = synthesize_trials(nest2, 1, sampling_strategy=IterateGen)
+    nest = Nest(outer, inner, [LatinSquare([color, word], name='P'),
+                               CoverAllCombinations(color, word)])
+    exps = synthesize_trials(nest, 1, sampling_strategy=IterateGen)
     for e in exps:
         assert _covers_all(e, colors)
 
@@ -290,7 +291,7 @@ def test_unmodeled_conflict_yields_hint(capsys):
     assert 'AtLeastKInARow' in out
 
 
-# ~~~~~~~~~~~~ Remaining validation errors ~~~~~~~~~~~~
+# ~~~~~~~~~~~~ Validation errors ~~~~~~~~~~~~
 
 def test_error_weighted_levels():
     colors = ['red', 'green', 'blue']

--- a/acceptance/test_cover_all_combinations.py
+++ b/acceptance/test_cover_all_combinations.py
@@ -18,12 +18,18 @@ def _stroop(n):
     return colors, color, word, congruency, inner
 
 
-def _stroop_nest(n, name=None):
+def _stroop_nest(n, extra_constraints=[]):
     colors, color, word, congruency, inner = _stroop(n)
     instance = Factor('instance', ['a', 'b'])
     outer = CrossBlock([instance], [instance], [])
-    nest = Nest(outer, inner, [CoverAllCombinations(color, word, name=name)])
+    nest = Nest(outer, inner,
+                [CoverAllCombinations(color, word)] + extra_constraints)
     return colors, color, word, nest
+
+
+def _covers_all(experiment, colors):
+    all_pairs = set((c, w) for c in colors for w in colors)
+    return set(zip(experiment['color'], experiment['word'])) == all_pairs
 
 
 # ~~~~~~~~~~~~ K computation (isolated) ~~~~~~~~~~~~
@@ -44,7 +50,7 @@ def test_required_instances_overlap_below_biggest_group():
     assert CoverAllCombinations(colr, size).required_instances(inner) == 2
 
 
-# ~~~~~~~~~~~~ Auto-sizing + coverage (end to end) ~~~~~~~~~~~~
+# ~~~~~~~~~~~~ Auto-sizing + coverage (Nest, end to end) ~~~~~~~~~~~~
 
 @pytest.mark.parametrize('n,expected_trials', [(3, 12), (4, 32)])
 def test_autosize_trial_count(n, expected_trials):
@@ -55,46 +61,236 @@ def test_autosize_trial_count(n, expected_trials):
 @pytest.mark.parametrize('n', [3, 4])
 def test_coverage_holds(n):
     colors, _, _, nest = _stroop_nest(n)
-    all_pairs = set((c, w) for c in colors for w in colors)
     exps = synthesize_trials(nest, 5, sampling_strategy=IterateGen)
     assert exps
     for e in exps:
-        assert set(zip(e['color'], e['word'])) == all_pairs
+        assert _covers_all(e, colors)
 
 
-# ~~~~~~~~~~~~ Validation / error paths ~~~~~~~~~~~~
+# ~~~~~~~~~~~~ Coverage on other constructs ~~~~~~~~~~~~
 
-def test_error_outer_factor_in_scope():
+def test_plain_crossblock_coverage_with_minimum_trials():
+    # A plain CrossBlock with an uncrossed factor, sized by the user via
+    # MinimumTrials, must still achieve coverage.
+    colors, color, word, congruency, _ = _stroop(3)
+    block = CrossBlock([congruency, color, word], [congruency, color],
+                       [CoverAllCombinations(color, word), MinimumTrials(12)])
+    exps = synthesize_trials(block, 3, sampling_strategy=IterateGen)
+    assert exps
+    for e in exps:
+        assert _covers_all(e, colors)
+
+
+def test_plain_crossblock_autosizes():
+    # No Nest and no MinimumTrials: the CrossBlock grows itself to fit coverage.
+    colors, color, word, congruency, _ = _stroop(3)
+    block = CrossBlock([congruency, color, word], [congruency, color],
+                       [CoverAllCombinations(color, word)])
+    assert block.trials_per_sample() == 12
+    exps = synthesize_trials(block, 3, sampling_strategy=IterateGen)
+    assert exps
+    for e in exps:
+        assert _covers_all(e, colors)
+
+
+def test_merge_autosizes():
+    # Coverage attached to a Merge: two fully-free factors, K = ceil(4/2) = 2
+    # passes of the [task] crossing -> 4 trials.
+    colr = Factor('colr', ['red', 'green'])
+    size = Factor('size', ['big', 'small'])
+    task = Factor('task', ['A', 'B'])
+    base = CrossBlock([task, colr, size], [task], [])
+    block = Merge([base], [CoverAllCombinations(colr, size)])
+    assert block.trials_per_sample() == 4
+    exps = synthesize_trials(block, 3, sampling_strategy=IterateGen)
+    assert exps
+    all_pairs = set((c, s) for c in ['red', 'green'] for s in ['big', 'small'])
+    for e in exps:
+        assert set(zip(e['colr'], e['size'])) == all_pairs
+
+
+def test_repeat_autosizes():
+    colors, color, word, congruency, _ = _stroop(3)
+    base = CrossBlock([congruency, color, word], [congruency, color], [])
+    block = Repeat(base, [CoverAllCombinations(color, word)])
+    assert block.trials_per_sample() == 12
+    exps = synthesize_trials(block, 3, sampling_strategy=IterateGen)
+    assert exps
+    for e in exps:
+        assert _covers_all(e, colors)
+
+
+# ~~~~~~~~~~~~ Coexistence (no construction-time guards) ~~~~~~~~~~~~
+
+def test_coexists_outer_factor_listed():
+    # Listing an outer factor no longer errors; the solver arbitrates.
     _, color, word, _, inner = _stroop(3)
     instance = Factor('instance', ['a', 'b'])
     outer = CrossBlock([instance], [instance], [])
-    with pytest.raises(ValueError):
-        Nest(outer, inner, [CoverAllCombinations(instance, color)])
+    Nest(outer, inner, [CoverAllCombinations(instance, color)])
 
 
-def test_error_overlap_sequential():
-    _, color, word, _, inner = _stroop(3)
+def test_coexists_sequential_shared_factor():
+    # Sequential pins word per position; the positional reconciliation still
+    # finds K=2 (12 trials), and synthesis must produce covering sequences.
+    colors, color, word, congruency, inner = _stroop(3)
     instance = Factor('instance', ['a', 'b'])
     outer = CrossBlock([instance], [instance], [])
-    with pytest.raises(ValueError):
-        Nest(outer, inner, [Sequential(word), CoverAllCombinations(color, word)])
+    nest = Nest(outer, inner, [CoverAllCombinations(color, word), Sequential(word)])
+    assert nest.trials_per_sample() == 12
+    exps = synthesize_trials(nest, 2, sampling_strategy=IterateGen)
+    assert exps
+    for e in exps:
+        assert _covers_all(e, colors)
+        # Sequential holds: word cycles through its levels in order.
+        assert e['word'] == (colors * 4)[:len(e['word'])]
 
 
-def test_error_overlap_latin_square():
-    _, color, word, _, inner = _stroop(3)
+def test_coexists_latin_square_shared_factors():
+    colors, color, word, nest = _stroop_nest(3, [])
+    _, c2, w2, _, inner2 = _stroop(3)
     instance = Factor('instance', ['a', 'b'])
     outer = CrossBlock([instance], [instance], [])
-    with pytest.raises(ValueError):
-        Nest(outer, inner, [LatinSquare([color, word], name='P'),
-                            CoverAllCombinations(color, word)])
+    # Same factors in LatinSquare and CoverAllCombinations: constructs, solver decides.
+    nest2 = Nest(outer, inner2, [LatinSquare([c2, w2], name='P'),
+                                 CoverAllCombinations(c2, w2)])
+    exps = synthesize_trials(nest2, 1, sampling_strategy=IterateGen)
+    for e in exps:
+        assert _covers_all(e, colors)
 
 
-def test_error_not_in_nest():
-    _, color, word, congruency, _ = _stroop(3)
+# ~~~~~~~~~~~~ Reconciliation ~~~~~~~~~~~~
+
+def test_exclude_shrinks_required_set():
+    # An excluded level's combinations are dropped from the required set rather
+    # than making coverage unsatisfiable.
+    colr = Factor('colr', ['red', 'green'])
+    size = Factor('size', ['big', 'small'])
+    task = Factor('task', ['A', 'B'])
+    block = CrossBlock([task, colr, size], [task],
+                       [CoverAllCombinations(colr, size), Exclude((colr, 'red'))])
+    assert block.trials_per_sample() == 2  # only 2 combos left to cover
+    exps = synthesize_trials(block, 3, sampling_strategy=IterateGen)
+    assert exps
+    for e in exps:
+        assert set(zip(e['colr'], e['size'])) == {('green', 'big'), ('green', 'small')}
+
+
+def test_exactly_k_below_coverage_errors():
+    # Coverage needs 3 word-red trials (red-red forced, green-red, blue-red);
+    # ExactlyK(1) can never be reconciled by adding instances -> named error.
+    colors, color, word, congruency, _ = _stroop(3)
     with pytest.raises(ValueError):
         CrossBlock([congruency, color, word], [congruency, color],
-                   [CoverAllCombinations(color, word)])
+                   [CoverAllCombinations(color, word), ExactlyK(1, (word, 'red'))])
 
+
+def test_exactly_k_reconciled():
+    # ExactlyK(4): 2 instances contribute 2 forced (red,red) + the 2 free
+    # word-red combos = exactly 4. K stays 2 -> 12 trials.
+    colors, color, word, congruency, _ = _stroop(3)
+    block = CrossBlock([congruency, color, word], [congruency, color],
+                       [CoverAllCombinations(color, word), ExactlyK(4, (word, 'red'))])
+    assert block.trials_per_sample() == 12
+    exps = synthesize_trials(block, 2, sampling_strategy=IterateGen)
+    assert exps
+    for e in exps:
+        assert _covers_all(e, colors)
+        assert e['word'].count('red') == 4
+
+
+def test_pin_grows_k():
+    # A Pin on a listed factor conservatively consumes one free pick, growing
+    # K from 2 to 3 (18 trials); coverage and the pin both hold.
+    colors, color, word, congruency, _ = _stroop(3)
+    block = CrossBlock([congruency, color, word], [congruency, color],
+                       [CoverAllCombinations(color, word), Pin(0, (word, 'red'))])
+    assert block.trials_per_sample() == 18
+    exps = synthesize_trials(block, 2, sampling_strategy=IterateGen)
+    assert exps
+    for e in exps:
+        assert _covers_all(e, colors)
+        assert e['word'][0] == 'red'
+
+
+# ~~~~~~~~~~~~ Analytic K lower bound ~~~~~~~~~~~~
+
+@pytest.mark.parametrize('n,expected_k', [(3, 2), (4, 3), (5, 4)])
+def test_k_lower_bound_tight_for_stroop(n, expected_k):
+    # The analytic floor equals the true K for the standard cases, so the
+    # matching scan does a single confirming check.
+    _, color, word, _, inner = _stroop(n)
+    cac = CoverAllCombinations(color, word)
+    (_, _, R_free, slots, _, sw, _) = cac._coverage_analysis(inner)
+    assert cac._k_lower_bound(R_free, slots, sw) == expected_k
+    assert cac.required_instances(inner) == expected_k
+
+
+def test_k_lower_bound_scan_corrects_upward():
+    # An overlapping-union case the signature bounds don't capture: slots 0 and 1
+    # jointly hold {a, b, c} (3 demands, 2 picks/instance) but no single signature
+    # nor the global bound sees it (slot 2's weight inflates global capacity).
+    slots = [{'a', 'c'}, {'b', 'c'}, {'d'}]
+    weights = [1, 1, 4]
+    R_free = {'a', 'b', 'c', 'd'}
+    assert CoverAllCombinations._k_lower_bound(R_free, slots, weights) == 1
+    assert CoverAllCombinations._min_instances(R_free, slots, weights) == 2
+
+
+# ~~~~~~~~~~~~ Weighted balances ~~~~~~~~~~~~
+
+def _stroop_weighted(n, incon_weight):
+    """Stroop with a weighted congruency ratio: 1 congruent : `incon_weight`
+    incongruent trials per color, per pass."""
+    colors = ['red', 'green', 'blue', 'yellow'][:n]
+    color = Factor('color', colors)
+    word = Factor('word', colors)
+    congruency = Factor('congruency', [
+        DerivedLevel('con', WithinTrial(lambda c, w: c == w, [color, word]), 1),
+        DerivedLevel('incon', WithinTrial(lambda c, w: c != w, [color, word]), incon_weight),
+    ])
+    return colors, color, word, congruency
+
+
+@pytest.mark.parametrize('incon_weight,expected_k', [(1, 3), (2, 2), (3, 1)])
+def test_required_instances_weighted(incon_weight, expected_k):
+    colors, color, word, congruency = _stroop_weighted(4, incon_weight)
+    inner = CrossBlock([congruency, color, word], [congruency, color], [])
+    assert CoverAllCombinations(color, word).required_instances(inner) == expected_k
+
+
+@pytest.mark.parametrize('incon_weight,expected_trials,expected_con,expected_incon',
+                         [(2, 24, 8, 16),   # K=2 passes of 12 -> 1:2 overall
+                          (3, 16, 4, 12)])  # natural ratio: one pass suffices
+def test_weighted_autosize_and_coverage(incon_weight, expected_trials,
+                                        expected_con, expected_incon):
+    colors, color, word, congruency = _stroop_weighted(4, incon_weight)
+    block = CrossBlock([congruency, color, word], [congruency, color],
+                       [CoverAllCombinations(color, word)])
+    assert block.trials_per_sample() == expected_trials
+    exps = synthesize_trials(block, 2, sampling_strategy=IterateGen)
+    assert exps
+    for e in exps:
+        assert _covers_all(e, colors)
+        assert e['congruency'].count('con') == expected_con
+        assert e['congruency'].count('incon') == expected_incon
+
+
+def test_unmodeled_conflict_yields_hint(capsys):
+    # In-a-row constraints aren't statically reconciled; a truly unsatisfiable
+    # combination yields 0 samples plus a printed hint (no crash).
+    colors, color, word, congruency, _ = _stroop(3)
+    block = CrossBlock([congruency, color, word], [congruency, color],
+                       [CoverAllCombinations(color, word),
+                        AtLeastKInARow(7, (word, 'red'))])
+    exps = synthesize_trials(block, 1, sampling_strategy=IterateGen)
+    assert exps == []
+    out = capsys.readouterr().out
+    assert 'CoverAllCombinations' in out
+    assert 'AtLeastKInARow' in out
+
+
+# ~~~~~~~~~~~~ Remaining validation errors ~~~~~~~~~~~~
 
 def test_error_weighted_levels():
     colors = ['red', 'green', 'blue']

--- a/docs/_source/api/constraints.rst
+++ b/docs/_source/api/constraints.rst
@@ -121,7 +121,7 @@ Constraints
 .. class:: sweetpea.LatinSquare(factors)
 
               Constrains an experiment so that the levels of `factors`
-              are combied in a Latin Square pattern. If the factor in
+              are combined in a Latin Square pattern. If the factor in
               `factors` with the most levels has N levels, then every
               N trials will include every level of every factor in
               `factors`. Furthermore, each subsequent sequence of N
@@ -132,7 +132,7 @@ Constraints
               The given `factors` are typically crossed in an
               experiment description, but they are not required to be
               crossed explicitly; a :class:`LatinSquare` constraint
-              effectivley forces a crossing as long as an experiment
+              effectively forces a crossing as long as an experiment
               includes enough trials.
 
               See :ref:`Latin Square Counterbalancing <latin-square-counterbalancing>`
@@ -140,6 +140,46 @@ Constraints
 
               :param factors: the factors forming the Latin Square pattern
               :type factors: List[Factor]
+              :rtype: Constraint
+
+.. class:: sweetpea.CoverAllCombinations(*factors)
+
+              Constrains an experiment so that its trials collectively
+              include every realizable combination of the levels of
+              `factors` at least once. A factor that is left out of a
+              crossing is otherwise assigned freely by the solver, so
+              nothing normally guarantees that a particular combination
+              ever appears; this constraint coordinates those free
+              choices.
+
+              Unlike most constraints, :class:`CoverAllCombinations`
+              can increase the number of trials: the count needed for
+              coverage is computed when the block is constructed, and
+              the block grows to fit, rounded up so that every crossing
+              still gets complete passes.
+
+              A combination that cannot occur is not required. That
+              includes combinations removed by an :class:`.Exclude`
+              constraint and combinations that contradict the predicate
+              of a :class:`.DerivedLevel`.
+
+              The trial count reconciles the effects of :class:`.Pin`,
+              :class:`.ExactlyK`, and :class:`.Sequential` constraints
+              on the listed factors. Ordering constraints such as
+              :class:`.AtMostKInARow` and :class:`.LatinSquare` are left
+              to the solver instead; when one of those conflicts with
+              coverage, :func:`.synthesize_trials` finds no sequences
+              and reports which constraints were not accounted for.
+
+              Levels of the listed factors must be unweighted, but
+              weighted levels elsewhere in the crossing are supported,
+              and they change the trial count accordingly.
+
+              See :ref:`Covering All Combinations <covering-all-combinations>`
+              for more information.
+
+              :param factors: the factors whose level combinations must all appear
+              :type factors: Factor
               :rtype: Constraint
 
 .. class:: sweetpea.ContinuousConstraint(factors, predicate)

--- a/docs/_source/api/main.rst
+++ b/docs/_source/api/main.rst
@@ -307,7 +307,7 @@ using :func:`.synthesize_trials`. Print generated trials using
 
    When `block` includes a :class:`.LatinSquare` constraint with a
    name, then each sample is further divided into segments for
-   differen diagonals.
+   different diagonals.
 
    :param block: the experiment description that was provided to :func:`.synthesize_trials`
    :type block: Block

--- a/docs/_source/guide/usage.rst
+++ b/docs/_source/guide/usage.rst
@@ -890,13 +890,13 @@ original `inner block`.
 Latin Square Counterbalancing
 -----------------------------
 
-A *Latin Square* is pattern that orders a crossing so that successive
-diagonals are first explored, which provides a more varierty for
+A *Latin Square* is a pattern that orders a crossing so that successive
+diagonals are first explored, which provides more variety for
 combinations within a trial subsequence than could be expected
 otherwise. A Latin Square can be particularly useful in an experiment
 with multiple participants, where each participant sees only a subset
 of the possible combinations, but still sees each level that could
-contribute to a combination---and all conbinations are generated
+contribute to a combination---and all combinations are generated
 across multiple participants. SweetPea supports Latin Square
 counterbalancing through the :class:`.LatinSquare` constraint, which
 expects a list of factors that are crossed.
@@ -906,7 +906,7 @@ A 2x2 Example
 
 Suppose we have `Font` (`small` or `big`) and `Color` (`red` or
 `green`) to cross, and we don't need every participant to see every
-combination. Since these factor each have 2 levels, there are 2
+combination. Since these factors each have 2 levels, there are 2
 diagonals in a Latin Square for the factors.
 
 .. list-table:: 2x2 Latin Square Diagonals
@@ -929,7 +929,7 @@ diagonals in a Latin Square for the factors.
 - **Diagonal 1**: (small, green) and (big, red)
 
 If we simply cross the factors, there's no guarantee that both colors
-will show up in the first two trails, only that all `Font`-`Color` word
+will show up in the first two trials, only that all `Font`-`Color`
 combinations will show up over four trials.
   
   .. doctest::
@@ -1020,9 +1020,9 @@ each generated experiment into sections labelled by participant name.
 Latin Squares as Crossing
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In the example with `Font` and `Color`, we crossed the factors to take
+In the example with `Font` and `Color`, we crossed the factors to make
 sure that each generated experiment covers all combinations. The
-:class:`LatinSquare` constraint does not require the factors that is
+:class:`LatinSquare` constraint does not require the factors that it
 is given to be crossed already. The constraint that it imposes is
 stronger than crossing in terms of trial sequences, but weaker than
 crossing because :class:`LatinSquare` does not imply a number of
@@ -1070,3 +1070,249 @@ enough trials.
     Participant 1:
     Task read | Font small | Color green
     Task read | Font big   | Color red  
+
+.. _covering-all-combinations:
+
+Covering All Combinations
+-------------------------
+
+Crossing factors guarantees that every combination of those factors
+appears, and it fixes the number of trials to match. A factor that is
+in a design but not in the crossing gets no such guarantee: the solver
+assigns its levels freely, subject only to whatever other constraints
+apply. Nothing stops it from picking the same level every time, so
+some combinations may never show up at all.
+
+The :class:`.CoverAllCombinations` constraint asks for a weaker
+guarantee than crossing: over the experiment as a whole, every
+combination of the listed factors must appear at least once.
+Individual trials still vary freely, and the design itself implies no
+particular number of trials, so SweetPea computes how many trials
+coverage needs and grows the block to fit.
+
+A Free-Factor Example
+^^^^^^^^^^^^^^^^^^^^^
+
+Suppose `task` is crossed, while `colr` and `size` are in the design
+but not crossed. Crossing `task` alone gives two trials.
+
+.. doctest::
+
+    >>> from sweetpea import (Factor, CrossBlock, CoverAllCombinations,
+    ...                       synthesize_trials, print_experiments)
+    >>> colr = Factor("colr", ["red", "green"])
+    >>> size = Factor("size", ["big", "small"])
+    >>> task = Factor("task", ["A", "B"])
+    >>> b = CrossBlock(design=[task, colr, size], crossing=[task], constraints=[])
+    >>> b.trials_per_sample()
+    2
+
+The `colr` and `size` factors are unconstrained. When we ran this
+while writing the guide, both trials came out identical apart from
+`task`, covering only one of the four `colr`-`size` combinations:
+
+.. doctest::
+    :options: +SKIP
+
+    >>> exps = synthesize_trials(b, 1)
+    >>> print_experiments(b, exps)
+    1 trial sequences found.
+    Experiment 0:
+    task B | colr red | size big
+    task A | colr red | size big
+
+Adding a :class:`.CoverAllCombinations` constraint over `colr` and
+`size` requires all four of their combinations to appear. Two trials
+cannot hold four combinations, so the block grows to four trials.
+
+.. doctest::
+
+    >>> cb = CrossBlock(design=[task, colr, size], crossing=[task],
+    ...                 constraints=[CoverAllCombinations(colr, size)])
+    >>> cb.trials_per_sample()
+    4
+
+.. doctest::
+    :options: +SKIP
+
+    >>> exps = synthesize_trials(cb, 1)
+    >>> print_experiments(cb, exps)
+    1 trial sequences found.
+    Experiment 0:
+    task B | colr red   | size big
+    task A | colr red   | size small
+    task B | colr green | size big
+    task A | colr green | size small
+
+Note that `task` is still crossed, so it stays balanced across the
+larger block; coverage grows the experiment in whole passes of the
+crossing rather than appending loose trials.
+
+How Many Trials
+^^^^^^^^^^^^^^^
+
+The trial count follows from how many combinations must be covered and
+how many of them a single pass of the crossing can supply. With
+`color` crossed and `word` free, each pass has three trials, and each
+of those trials can pair its own color with any word. There are nine
+`color`-`word` combinations to cover and three per pass, so three
+passes---nine trials---are required.
+
+.. doctest::
+
+    >>> color = Factor("color", ["red", "green", "blue"])
+    >>> word  = Factor("word",  ["red", "green", "blue"])
+    >>> b = CrossBlock(design=[color, word], crossing=[color],
+    ...                constraints=[CoverAllCombinations(color, word)])
+    >>> b.trials_per_sample()
+    9
+
+.. doctest::
+    :options: +SKIP
+
+    >>> exps = synthesize_trials(b, 1)
+    >>> print_experiments(b, exps)
+    1 trial sequences found.
+    Experiment 0:
+    color blue  | word green
+    color red   | word green
+    color blue  | word blue
+    color green | word red
+    color red   | word blue
+    color red   | word red
+    color blue  | word red
+    color green | word blue
+    color green | word green
+
+Combinations that cannot occur are not counted. An :class:`.Exclude`
+constraint removes them from the required set, which can lower the
+trial count rather than making the experiment unsatisfiable---here,
+ruling out one `word` level leaves six combinations and six trials.
+
+.. doctest::
+
+    >>> from sweetpea import Exclude
+    >>> eb = CrossBlock(design=[color, word], crossing=[color],
+    ...                 constraints=[CoverAllCombinations(color, word),
+    ...                              Exclude((word, "red"))])
+    >>> eb.trials_per_sample()
+    6
+
+Combinations that contradict the predicate of a :class:`.DerivedLevel`
+are dropped the same way.
+
+Coverage Across Participants
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Coverage applies to the experiment as a whole, so it composes with
+:class:`.Nest`. Each participant runs a pass of the inner block and
+sees only some of the combinations, while the union over participants
+covers all of them. Nesting the nine-trial
+requirement inside a two-participant outer crossing rounds up to
+twelve trials, so that each participant gets a whole number of inner
+passes.
+
+.. doctest::
+
+    >>> from sweetpea import Nest
+    >>> inner = CrossBlock(design=[color, word], crossing=[color], constraints=[])
+    >>> participant = Factor("participant", ["p1", "p2"])
+    >>> outer = CrossBlock(design=[participant], crossing=[participant],
+    ...                    constraints=[])
+    >>> nb = Nest(outer_block=outer, inner_block=inner,
+    ...           constraints=[CoverAllCombinations(color, word)])
+    >>> nb.trials_per_sample()
+    12
+
+.. doctest::
+    :options: +SKIP
+
+    >>> exps = synthesize_trials(nb, 1)
+    >>> print_experiments(nb, exps)
+    1 trial sequences found.
+    Experiment 0:
+    participant p2 | color red   | word green
+    participant p2 | color blue  | word green
+    participant p2 | color green | word green
+    participant p1 | color green | word red
+    participant p1 | color blue  | word blue
+    participant p1 | color red   | word red
+    participant p1 | color green | word blue
+    participant p1 | color blue  | word red
+    participant p1 | color red   | word red
+    participant p2 | color green | word blue
+    participant p2 | color blue  | word red
+    participant p2 | color red   | word blue
+
+Neither participant saw all nine combinations---each repeated one and
+missed three---but between them every combination appeared. A
+:class:`.CoverAllCombinations` constraint can also be attached to a
+:class:`.MultiCrossBlock`, a :class:`.Merge`, or a :class:`.Repeat`.
+
+Interaction With Other Constraints
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Because coverage decides the number of trials, it has to account for
+other constraints that compete for the same trials. Constraints that
+fix or limit the levels of a listed factor---:class:`.Pin`,
+:class:`.ExactlyK`, and :class:`.Sequential`---are folded into that
+calculation. A :class:`.Pin` claims a trial for a specific level, for
+instance, leaving one fewer trial available for coverage and pushing
+the block up to a fourth pass.
+
+.. doctest::
+
+    >>> from sweetpea import Pin
+    >>> pb = CrossBlock(design=[color, word], crossing=[color],
+    ...                 constraints=[CoverAllCombinations(color, word),
+    ...                              Pin(0, (word, "red"))])
+    >>> pb.trials_per_sample()
+    12
+
+When such a constraint cannot be reconciled at any number of trials,
+the conflict is reported as the block is built. Covering all
+combinations puts `word` at `red` in at least three trials, so an
+:class:`.ExactlyK` allowing only one is impossible no matter how long
+the experiment runs.
+
+.. doctest::
+
+    >>> from sweetpea import ExactlyK
+    >>> CrossBlock(design=[color, word], crossing=[color],
+    ...            constraints=[CoverAllCombinations(color, word),
+    ...                         ExactlyK(1, (word, "red"))])
+    Traceback (most recent call last):
+      ...
+    ValueError: ('CoverAllCombinations', "covering all combinations requires at least 3 trials with 'word red' but an ExactlyK constraint allows exactly 1")
+
+Ordering constraints---the in-a-row family and
+:class:`.LatinSquare`---are *not* folded into the trial count, since
+they restrict how trials may be arranged rather than how many are
+needed. The solver arbitrates those instead. If they turn out to
+conflict with coverage, synthesis finds nothing and reports which
+constraints were left out of the calculation, so that you can supply
+more trials with a :class:`.MinimumTrials` constraint.
+
+.. doctest::
+    :options: +SKIP
+
+    >>> from sweetpea import AtLeastKInARow
+    >>> ub = CrossBlock(design=[color, word], crossing=[color],
+    ...                 constraints=[CoverAllCombinations(color, word),
+    ...                              AtLeastKInARow(7, (word, "red"))])
+    >>> exps = synthesize_trials(ub, 1)
+    Sampling 1 trial sequences using NonUniformGen.
+    Encoding experiment constraints...
+    Running CryptoMiniSat...
+    No trial sequences found: the constraints could not be satisfied together with CoverAllCombinations(color, word). Constraints of kind AtLeastKInARow are not folded into coverage auto-sizing; a MinimumTrials constraint can provide additional trials.
+    >>> exps
+    []
+
+Weighted Levels
+^^^^^^^^^^^^^^^
+
+Weights on a crossed factor change how many trials a pass contains,
+and coverage takes that into account when sizing the block. The levels
+of the factors listed in :class:`.CoverAllCombinations` itself must be
+unweighted, however, since the meaning of a weight on a covered
+combination is not currently defined.

--- a/sweetpea/_internal/block.py
+++ b/sweetpea/_internal/block.py
@@ -45,6 +45,10 @@ class Block:
     correctly.
     """
 
+    # The constraints as given by the user, before desugaring; assigned by
+    # subclasses during construction.
+    orig_constraints: List[Constraint]
+
     def __init__(self,
                  design: List[Factor],
                  crossings: List[List[Factor]],
@@ -288,6 +292,13 @@ class Block:
         this block configuration.
 
         Analogous to the old ``__fully_cross_size`` function.
+        """
+        pass
+
+    @abstractmethod
+    def common_preamble_size(self):
+        """Indicates the number of leading preamble trials shared by all of the
+        block's crossings.
         """
         pass
 

--- a/sweetpea/_internal/constraint.py
+++ b/sweetpea/_internal/constraint.py
@@ -1321,9 +1321,10 @@ class CoverAllCombinations(Constraint):
         return list(c) if c is not None else []
 
     def _combo_is_impossible(self, block, di) -> bool:
-        """Block-agnostic realizability: explicit/implicit exclusions, plus
-        consistency of every derived factor present in the combination (no
-        assumption that the derived factor sits in ``crossings[0]``)."""
+        """Whether a combination is unrealizable: excluded, or inconsistent with
+        the definition of a derived factor in the combination. (Unlike
+        ``Block.is_excluded_or_inconsistent_combination``, checks every derived
+        factor present, not just those in the block's first crossing.)"""
         if block.is_excluded_combination(di):
             return True
         for f in di:
@@ -1565,8 +1566,8 @@ class CoverAllCombinations(Constraint):
 
     @staticmethod
     def _k_lower_bound(R_free, slots, slot_weights=None):
-        """Analytic floor for the instance count, so the matching scan can start
-        near the answer instead of at 1:
+        """Analytic floor for the instance count, letting the matching scan start
+        near the answer:
 
         - global capacity: ceil(|R_free| / total picks per instance);
         - Hall-style signature bounds: combos grouped by the exact set of slots
@@ -1654,17 +1655,14 @@ class CoverAllCombinations(Constraint):
 
     def validate(self, block: Block) -> None:
         who = "CoverAllCombinations"
-        # Weighted levels are not supported yet (checked on the factor object directly:
-        # weighted factors get desugared, so a has_factor-based check would otherwise
-        # mask the real reason).
+        # The weight check must precede validate_factor: desugaring replaces
+        # weighted factors, so validate_factor would report a misleading
+        # "not found" instead.
         for f in self.factors:
             if f.level_weight_sum() != len(f.levels):
                 raise ValueError((who, "weighted levels not currently supported"))
         for f in self.factors:
             validate_factor(block, f)
-        # No coexistence guards: other constraints (LatinSquare, Sequential, Pin, ...)
-        # are reconciled into the sizing computation where statically possible, and
-        # otherwise arbitrated by the SAT solver in the joint problem.
 
     def apply(self, block: Block, backend_request: BackendRequest) -> None:
         (_, _, R_free, _, combo_levels, _, _) = self._coverage_analysis(
@@ -1685,7 +1683,7 @@ class CoverAllCombinations(Constraint):
                 fresh += 1
                 state_vars.append(sv)
                 formula_parts.append(Iff(sv, And(list(block.encode_combination(levels, t)))))
-            # "at least once": at least one trial instantiates this combination.
+            # At least one trial must instantiate this combination.
             formula_parts.append(Or(state_vars))
 
         (cnf, new_fresh) = block.cnf_fn(And(formula_parts), fresh)

--- a/sweetpea/_internal/constraint.py
+++ b/sweetpea/_internal/constraint.py
@@ -1270,3 +1270,231 @@ class Sequential(Constraint):
 def _val_name(x):
     # Works for Level objects or plain strings
     return getattr(x, "name", x)
+
+
+class CoverAllCombinations(Constraint):
+    """Coordinates the otherwise-free factor choices across the inner-block instances
+    of a :class:`.Nest`, so that the *union* of all instances covers every realizable
+    combination of `factors` at least once.
+
+    The number of inner-block instances needed for coverage is computed automatically,
+    and the enclosing :class:`.Nest` is grown to fit (see :class:`.Nest`).
+
+    Usage::
+
+        Nest(outer, inner, [CoverAllCombinations(color, word)])
+        Nest(outer, inner, [CoverAllCombinations(color, word, name="Participant")])
+
+    All `factors` must belong to the inner block. When `name` is given,
+    :func:`.print_experiments` sections each experiment by inner-block instance,
+    labeled ``"<name> N:"``.
+    """
+
+    def __init__(self, *factors, name: Optional[str] = None):
+        who = "CoverAllCombinations"
+        factor_list = list(factors)
+        if factor_list == []:
+            raise ValueError(who, "factor list must be non-empty")
+        argcheck(who, factor_list, make_islistof(Factor), "factors")
+        self.factors = factor_list
+        self.name = name
+        # Set by Nest during construction (the inner block and its post-preamble length),
+        # so that validate/apply and print sectioning have the inner context they need.
+        self._inner_block = cast(Optional[MultiCrossBlockRepeat], None)
+        self._inner_len = cast(Optional[int], None)
+
+    # ~~~~~~~~~~~~~~ Coverage analysis (the "K" computation) ~~~~~~~~~~~~~~
+
+    def _coverage_analysis(self, inner_block):
+        """Structural analysis over `self.factors` for the given inner block.
+
+        Returns ``(R, forced, R_free, slots, combo_levels)`` where:
+
+        - ``R``: realizable listed-factor combos, each a tuple of
+          ``(factor_name, level_name)`` pairs in `self.factors` order;
+        - ``forced``: combos guaranteed in *every* instance by the inner crossing
+          (cells where the listed factors are fully pinned);
+        - ``R_free``: ``R - forced``, the combos that must be placed in free slots;
+        - ``slots``: for each free inner-crossing cell, the set of ``R_free`` combos it
+          can instantiate (a "slot-type", with capacity one pick per instance);
+        - ``combo_levels``: maps each combo to its ``{factor: level}`` dict (for CNF).
+        """
+        listed = self.factors
+        if not inner_block.crossings:
+            return (set(), set(), set(), [], {})
+        crossing_factors = list(inner_block.crossings[0])
+        listed_free = [f for f in listed if f not in crossing_factors]
+        crossing_level_lists = [list(f.levels) for f in crossing_factors]
+        free_level_lists = [list(f.levels) for f in listed_free]
+        free_assignments = list(product(*free_level_lists)) if listed_free else [()]
+
+        R = set()                      # type: set
+        forced = set()                 # type: set
+        slot_sets = []                 # type: List[set]
+        combo_levels = {}              # type: Dict[tuple, Dict[Factor, Any]]
+        for cell in product(*crossing_level_lists):
+            di_cell = {crossing_factors[i]: cell[i] for i in range(len(crossing_factors))}
+            cand = set()
+            for fa in free_assignments:
+                di = dict(di_cell)
+                for j, f in enumerate(listed_free):
+                    di[f] = fa[j]
+                if inner_block.is_excluded_or_inconsistent_combination(di):
+                    continue
+                combo = tuple((f.name, di[f].name) for f in listed)
+                cand.add(combo)
+                if combo not in combo_levels:
+                    combo_levels[combo] = {f: di[f] for f in listed}
+            if not cand:
+                continue
+            R |= cand
+            if len(cand) == 1:
+                forced |= cand
+            else:
+                slot_sets.append(cand)
+        R_free = R - forced
+        slots = [s & R_free for s in slot_sets]
+        slots = [s for s in slots if s]
+        return (R, forced, R_free, slots, combo_levels)
+
+    def required_instances(self, inner_block=None):
+        """Minimum number of inner-block instances (K) needed to cover ``R_free``."""
+        inner_block = inner_block if inner_block is not None else self._inner_block
+        (_, _, R_free, slots, _) = self._coverage_analysis(inner_block)
+        return self._min_instances(R_free, slots)
+
+    @staticmethod
+    def _min_instances(R_free, slots):
+        who = "CoverAllCombinations"
+        if not R_free:
+            return 1
+        combos = list(R_free)
+        for c in combos:
+            if not any(c in s for s in slots):
+                raise ValueError((who, "combination {} cannot be produced in any free "
+                                       "trial; coverage is impossible".format(c)))
+        upper = len(combos)
+        for k in range(1, upper + 1):
+            if CoverAllCombinations._feasible(combos, slots, k):
+                return k
+        return upper
+
+    @staticmethod
+    def _feasible(combos, slots, k):
+        """Can `combos` be covered with each slot-type covering at most `k` combos?
+
+        Bipartite matching where each slot-type has `k` copies (capacity), via Kuhn's
+        augmenting-path algorithm. Sizes are small for experimental designs.
+        """
+        adj = [[si for si, s in enumerate(slots) if c in s] for c in combos]
+        slot_copy_match = {}  # type: Dict[tuple, int]
+
+        def augment(ci, visited):
+            for si in adj[ci]:
+                for copy in range(k):
+                    key = (si, copy)
+                    if key in visited:
+                        continue
+                    visited.add(key)
+                    if key not in slot_copy_match or augment(slot_copy_match[key], visited):
+                        slot_copy_match[key] = ci
+                        return True
+            return False
+
+        matched = 0
+        for ci in range(len(combos)):
+            if augment(ci, set()):
+                matched += 1
+        return matched == len(combos)
+
+    # ~~~~~~~~~~~~~~ Constraint interface ~~~~~~~~~~~~~~
+
+    def section_length(self, block) -> int:
+        """Trials per inner-block instance, used by print_experiments sectioning."""
+        return self._inner_len if self._inner_len else 0
+
+    def uses_factor(self, f: Factor) -> bool:
+        return any(factor.uses_factor(f) for factor in self.factors)
+
+    def desugar(self, replacements: dict) -> List[Constraint]:
+        factors = [replacements.get(f, [f, f])[1] for f in self.factors]
+        c = CoverAllCombinations(*factors, name=self.name)
+        c._inner_block = self._inner_block
+        c._inner_len = self._inner_len
+        return [c]
+
+    def validate(self, block: Block) -> None:
+        who = "CoverAllCombinations"
+        # Check weights first (on the factor object directly): weighted factors get
+        # desugared, so a has_factor-based check would otherwise mask the real reason.
+        for f in self.factors:
+            if f.level_weight_sum() != len(f.levels):
+                raise ValueError((who, "weighted levels not currently supported"))
+        for f in self.factors:
+            validate_factor(block, f)
+        if self._inner_block is None:
+            raise ValueError((who, "CoverAllCombinations is only meaningful inside a Nest"))
+        # All listed factors must live in the inner block (v1 scope).
+        for f in self.factors:
+            if not self._inner_block.has_factor(f):
+                raise ValueError((who, "factor '{}' must be in the inner block".format(f.name)))
+        # Must be disjoint from any LatinSquare / Sequential on the same block: those
+        # would pin a factor the coverage model assumes free.
+        for ct in block.constraints:
+            if isinstance(ct, LatinSquare):
+                shared = [f.name for f in self.factors if f in ct.factors]
+                if shared:
+                    raise ValueError((who, "factors {} also appear in a LatinSquare "
+                                           "constraint".format(shared)))
+            if isinstance(ct, Sequential):
+                if ct.factor in self.factors:
+                    raise ValueError((who, "factor '{}' also appears in a Sequential "
+                                           "constraint".format(ct.factor.name)))
+        # Feasibility (also raises on an impossible-to-cover combination).
+        self.required_instances(self._inner_block)
+
+    def apply(self, block: Block, backend_request: BackendRequest) -> None:
+        (_, _, R_free, _, combo_levels) = self._coverage_analysis(self._inner_block)
+        if not R_free:
+            return
+        preamble = block.common_preamble_size()
+        num_trials = block.trials_per_sample()
+        trials = list(range(1 + preamble, num_trials + 1))
+
+        fresh = backend_request.fresh
+        formula_parts = cast(List[Formula], [])
+        for combo in R_free:
+            levels = combo_levels[combo]
+            state_vars = []
+            for t in trials:
+                sv = fresh
+                fresh += 1
+                state_vars.append(sv)
+                formula_parts.append(Iff(sv, And(list(block.encode_combination(levels, t)))))
+            # "at least once": at least one trial instantiates this combination.
+            formula_parts.append(Or(state_vars))
+
+        (cnf, new_fresh) = block.cnf_fn(And(formula_parts), fresh)
+        backend_request.cnfs.append(cnf)
+        backend_request.fresh = new_fresh
+
+    def potential_sample_conforms(self, sample: dict, block: Block) -> bool:
+        (_, _, R_free, _, _) = self._coverage_analysis(self._inner_block)
+        if not R_free:
+            return True
+        num_trials = block.trials_per_sample()
+        for combo in R_free:
+            need = dict(combo)  # factor_name -> level_name
+            found = False
+            for t in range(num_trials):
+                if all(sample[f][t].name == need[f.name] for f in self.factors):
+                    found = True
+                    break
+            if not found:
+                return False
+        return True
+
+    def __repr__(self):
+        return "CoverAllCombinations({}{})".format(
+            ", ".join([f.name for f in self.factors]),
+            ", name={!r}".format(self.name) if self.name else "")

--- a/sweetpea/_internal/constraint.py
+++ b/sweetpea/_internal/constraint.py
@@ -1273,56 +1273,94 @@ def _val_name(x):
 
 
 class CoverAllCombinations(Constraint):
-    """Coordinates the otherwise-free factor choices across the inner-block instances
-    of a :class:`.Nest`, so that the *union* of all instances covers every realizable
+    """Requires that the trials of an experiment collectively include every realizable
     combination of `factors` at least once.
 
-    The number of inner-block instances needed for coverage is computed automatically,
-    and the enclosing :class:`.Nest` is grown to fit (see :class:`.Nest`).
+    Factors left out of a crossing are otherwise assigned freely by the solver; this
+    constraint coordinates those free choices so that the union of all trials covers
+    every combination. The number of trials needed is computed automatically and the
+    block is grown to fit (see the auto-sizing notes on the block constructors).
 
     Usage::
 
         Nest(outer, inner, [CoverAllCombinations(color, word)])
-        Nest(outer, inner, [CoverAllCombinations(color, word, name="Participant")])
-
-    All `factors` must belong to the inner block. When `name` is given,
-    :func:`.print_experiments` sections each experiment by inner-block instance,
-    labeled ``"<name> N:"``.
+        CrossBlock(design, crossing, [CoverAllCombinations(color, word)])
     """
 
-    def __init__(self, *factors, name: Optional[str] = None):
+    def __init__(self, *factors):
         who = "CoverAllCombinations"
         factor_list = list(factors)
         if factor_list == []:
             raise ValueError(who, "factor list must be non-empty")
         argcheck(who, factor_list, make_islistof(Factor), "factors")
         self.factors = factor_list
-        self.name = name
-        # Set by Nest during construction (the inner block and its post-preamble length),
-        # so that validate/apply and print sectioning have the inner context they need.
+        # Set by Nest during construction: the inner block whose crossing determines
+        # which listed factors are pinned vs. free. None for other block types, in
+        # which case the attached block itself is analyzed.
         self._inner_block = cast(Optional[MultiCrossBlockRepeat], None)
-        self._inner_len = cast(Optional[int], None)
 
     # ~~~~~~~~~~~~~~ Coverage analysis (the "K" computation) ~~~~~~~~~~~~~~
 
-    def _coverage_analysis(self, inner_block):
-        """Structural analysis over `self.factors` for the given inner block.
+    def _analysis_block(self, block):
+        """The block whose crossing structure determines pinned vs. free listed
+        factors: the inner block for a Nest, otherwise the attached block itself."""
+        return self._inner_block if self._inner_block is not None else block
 
-        Returns ``(R, forced, R_free, slots, combo_levels)`` where:
+    def _cell_crossing(self, block):
+        """The crossing whose cells form one instance "pass": the first crossing
+        that pins a listed factor, or the largest crossing when none does."""
+        for c in block.crossings:
+            if any(f in c for f in self.factors):
+                return c
+        if block.crossings:
+            return max(block.crossings, key=len)
+        return None
+
+    def _cell_factors(self, block):
+        c = self._cell_crossing(block)
+        return list(c) if c is not None else []
+
+    def _combo_is_impossible(self, block, di) -> bool:
+        """Block-agnostic realizability: explicit/implicit exclusions, plus
+        consistency of every derived factor present in the combination (no
+        assumption that the derived factor sits in ``crossings[0]``)."""
+        if block.is_excluded_combination(di):
+            return True
+        for f in di:
+            if isinstance(f, DerivedFactor) and not f.has_complex_window:
+                l = di[f]
+                if isinstance(l, DerivedLevel) and all(wf in di for wf in l.window.factors):
+                    args = [di[wf].name for wf in l.window.factors]
+                    if not l.window.predicate(*args):
+                        return True
+        return False
+
+    def _coverage_analysis(self, block, exclusion_block=None):
+        """Structural analysis over `self.factors` for the given analysis block.
+        When `exclusion_block` is given (e.g. the merged block of a Nest), its
+        exclusions are folded into realizability as well, so that an Exclude at
+        any level simply removes combinations from the required set.
+
+        Returns ``(R, forced, R_free, slots, combo_levels, slot_weights,
+        forced_weights)`` where:
 
         - ``R``: realizable listed-factor combos, each a tuple of
           ``(factor_name, level_name)`` pairs in `self.factors` order;
-        - ``forced``: combos guaranteed in *every* instance by the inner crossing
+        - ``forced``: combos guaranteed in *every* instance by the crossing
           (cells where the listed factors are fully pinned);
         - ``R_free``: ``R - forced``, the combos that must be placed in free slots;
-        - ``slots``: for each free inner-crossing cell, the set of ``R_free`` combos it
-          can instantiate (a "slot-type", with capacity one pick per instance);
-        - ``combo_levels``: maps each combo to its ``{factor: level}`` dict (for CNF).
+        - ``slots``: for each free crossing cell, the set of ``R_free`` combos it
+          can instantiate (a "slot-type");
+        - ``combo_levels``: maps each combo to its ``{factor: level}`` dict (for CNF);
+        - ``slot_weights``: parallel to ``slots``, each cell's combination weight —
+          a weight-w cell appears w times per instance, giving w picks;
+        - ``forced_weights``: per forced combo, its occurrences per instance
+          (sum of the combination weights of the cells that force it).
         """
         listed = self.factors
-        if not inner_block.crossings:
-            return (set(), set(), set(), [], {})
-        crossing_factors = list(inner_block.crossings[0])
+        crossing_factors = self._cell_factors(block)
+        if not crossing_factors:
+            return (set(), set(), set(), [], {}, [], {})
         listed_free = [f for f in listed if f not in crossing_factors]
         crossing_level_lists = [list(f.levels) for f in crossing_factors]
         free_level_lists = [list(f.levels) for f in listed_free]
@@ -1330,7 +1368,9 @@ class CoverAllCombinations(Constraint):
 
         R = set()                      # type: set
         forced = set()                 # type: set
+        forced_weights = {}            # type: Dict[tuple, int]
         slot_sets = []                 # type: List[set]
+        slot_set_weights = []          # type: List[int]
         combo_levels = {}              # type: Dict[tuple, Dict[Factor, Any]]
         for cell in product(*crossing_level_lists):
             di_cell = {crossing_factors[i]: cell[i] for i in range(len(crossing_factors))}
@@ -1339,7 +1379,10 @@ class CoverAllCombinations(Constraint):
                 di = dict(di_cell)
                 for j, f in enumerate(listed_free):
                     di[f] = fa[j]
-                if inner_block.is_excluded_or_inconsistent_combination(di):
+                if self._combo_is_impossible(block, di):
+                    continue
+                if (exclusion_block is not None and exclusion_block is not block
+                        and exclusion_block.is_excluded_combination(di)):
                     continue
                 combo = tuple((f.name, di[f].name) for f in listed)
                 cand.add(combo)
@@ -1349,22 +1392,206 @@ class CoverAllCombinations(Constraint):
                 continue
             R |= cand
             if len(cand) == 1:
-                forced |= cand
+                combo = next(iter(cand))
+                forced.add(combo)
+                forced_weights[combo] = forced_weights.get(combo, 0) + combination_weight(cell)
             else:
                 slot_sets.append(cand)
+                slot_set_weights.append(combination_weight(cell))
         R_free = R - forced
-        slots = [s & R_free for s in slot_sets]
-        slots = [s for s in slots if s]
-        return (R, forced, R_free, slots, combo_levels)
+        slots = []                     # type: List[set]
+        slot_weights = []              # type: List[int]
+        for s, w in zip(slot_sets, slot_set_weights):
+            s2 = s & R_free
+            if s2:
+                slots.append(s2)
+                slot_weights.append(w)
+        return (R, forced, R_free, slots, combo_levels, slot_weights, forced_weights)
 
-    def required_instances(self, inner_block=None):
-        """Minimum number of inner-block instances (K) needed to cover ``R_free``."""
-        inner_block = inner_block if inner_block is not None else self._inner_block
-        (_, _, R_free, slots, _) = self._coverage_analysis(inner_block)
-        return self._min_instances(R_free, slots)
+    def required_instances(self, block=None):
+        """Minimum number of instances (K) needed to cover ``R_free``."""
+        if block is None:
+            block = self._inner_block
+        (_, _, R_free, slots, _, slot_weights, _) = self._coverage_analysis(block)
+        return self._min_instances(R_free, slots, slot_weights)
+
+    def _relevant_constraints(self, sizing_block):
+        """The sizing block's constraints that are statically reconciled into the
+        coverage model: Pins and (global) ExactlyK / Sequential on listed factors.
+        Ordering constraints (the in-a-row family) and LatinSquare are left to the
+        SAT solver, which remains the final arbiter."""
+        listed = set(self.factors)
+        pins = []          # type: List[Pin]
+        caps = []          # type: List[ExactlyK]
+        seqs = []          # type: List[Sequential]
+        for ct in sizing_block.constraints:
+            if isinstance(ct, Pin) and ct.factor in listed:
+                pins.append(ct)
+            elif isinstance(ct, ExactlyK) and not isinstance(ct.level, Factor) \
+                    and ct.level.factor in listed:
+                caps.append(ct)
+            elif isinstance(ct, Sequential) and ct.factor in listed:
+                seqs.append(ct)
+        return (pins, caps, seqs)
+
+    def _feasible_at(self, k, instance_len, R_free, forced, slots, pins, caps,
+                     seq_free, sizing_block, slot_weights=None, forced_weights={}):
+        """Whether coverage is achievable with `k` instances, once the statically
+        modeled constraint effects are folded in jointly."""
+        # ExactlyK caps: the capped level's minimum occurrences at k instances are
+        # k * (forced occurrences per instance) + (one per required free combo).
+        # The forced term grows with k, so feasibility is NOT monotone in k —
+        # which is why the caller scans k linearly instead of binary-searching.
+        for ct in caps:
+            fname, lname = ct.level.factor.name, ct.level.name
+            forced_l = sum(forced_weights.get(c, 1) for c in forced if (fname, lname) in c)
+            free_l = sum(1 for c in R_free if (fname, lname) in c)
+            if k * forced_l + free_l > ct.k:
+                return False
+        if seq_free:
+            return self._positional_feasible(k, instance_len, R_free, seq_free,
+                                             sizing_block)
+        # Pins on listed factors conservatively consume one free pick each:
+        # modeled as dummy combos that any slot can serve.
+        dummies = ["_pin{}".format(i) for i in range(len(pins))]
+        combos = list(R_free) + dummies
+        slots_ext = [s | set(dummies) for s in slots]
+        return self._feasible(combos, slots_ext, k, slot_weights)
+
+    def _positional_feasible(self, k, instance_len, R_free, seq_free, sizing_block):
+        """Coverage feasibility when a Sequential pins a listed free factor to a
+        value per trial position. Each post-preamble position can host at most
+        one required combo, and only combos whose sequential-factor values match
+        that position. (Cell-per-position exclusivity is relaxed; the solver
+        arbitrates residual conflicts.)"""
+        T = k * instance_len
+        pos_sets = []
+        for pos in range(T):
+            allowed = {}
+            for ct in seq_free:
+                # Sequential holds each level for `sus` trials then advances,
+                # wrapping around — so the level at `pos` is fully determined.
+                f = ct.factor
+                sus = sizing_block.factor_to_sustain_count.get(f, 1)
+                allowed[f.name] = f.levels[(pos // sus) % len(f.levels)].name
+            s = set(c for c in R_free
+                    if all(dict(c).get(fn) == ln for fn, ln in allowed.items()))
+            pos_sets.append(s)
+        return self._feasible(list(R_free), pos_sets, 1)
+
+    def autosize_trials(self, block) -> int:
+        """Total trials `block` needs for coverage, or 0 when no static sizing
+        applies (the block then keeps its user-specified size and the SAT solver
+        arbitrates).
+
+        Runs the K-search over the joint model: propose an instance count K,
+        fold in the statically modeled effects of the block's other constraints,
+        grow K until the capacitated matching covers the required set (or a cap
+        is hit). Provably-impossible coverage raises a construction-time error
+        naming the conflict. The resulting trial count is rounded up so that
+        every crossing of `block` keeps complete passes (e.g. a Nest's outer
+        crossing stays balanced when K is not a multiple of its size).
+        """
+        who = "CoverAllCombinations"
+        analysis = self._analysis_block(block)
+        if analysis is not block and not all(analysis.has_factor(f) for f in self.factors):
+            # Nest with a listed factor outside the inner block: not statically modeled.
+            return 0
+        cell_crossing = self._cell_crossing(analysis)
+        if cell_crossing is None:
+            return 0
+        # Listed factors crossed outside the cell crossing aren't statically modeled.
+        for c in analysis.crossings:
+            if c is not cell_crossing and any(f in c for f in self.factors):
+                return 0
+        (R, forced, R_free, slots, _, slot_weights, forced_weights) = \
+            self._coverage_analysis(analysis, exclusion_block=block)
+        (pins, caps, seqs) = self._relevant_constraints(block)
+        # Definitive check: `required` = the capped level's occurrences at K=1
+        # (each free combo at least once + each forced combo at its per-instance
+        # weight). Adding instances only increases the forced term, so a cap
+        # below this can never be reconciled at any K.
+        for ct in caps:
+            fname, lname = ct.level.factor.name, ct.level.name
+            required = (sum(1 for c in R_free if (fname, lname) in c)
+                        + sum(forced_weights.get(c, 1) for c in forced
+                              if (fname, lname) in c))
+            if required > ct.k:
+                raise ValueError((who,
+                                  "covering all combinations requires at least {} trials "
+                                  "with '{} {}' but an ExactlyK constraint allows exactly "
+                                  "{}".format(required, fname, lname, ct.k)))
+        k_opt = self._min_instances(R_free, slots, slot_weights)
+        if analysis is not block:
+            # Nest: one instance = one inner-block pass.
+            instance_len = analysis.trials_per_sample() - analysis.common_preamble_size()
+        else:
+            # crossing_size already folds in the crossing's sustain count.
+            instance_len = block.crossing_size(cell_crossing)
+        if instance_len <= 0:
+            return 0
+        # Sequential enrichment applies to listed factors the cells leave free.
+        cell_factors = self._cell_factors(analysis)
+        seq_free = [ct for ct in seqs if ct.factor not in cell_factors]
+        # Scan ceiling: |R_free| instances provably suffice for the plain model
+        # (see _min_instances), so twice that (or twice k_opt) leaves headroom
+        # for what constraints consume; exhausting it => irreconcilable.
+        cap = max(len(R), k_opt) * 2
+        k = k_opt
+        while k <= cap:
+            if self._feasible_at(k, instance_len, R_free, forced, slots, pins, caps,
+                                 seq_free, block, slot_weights, forced_weights):
+                break
+            k += 1
+        else:
+            conflicting = [repr(ct) for ct in (pins + caps + seq_free)]
+            raise ValueError((who,
+                              "no trial count up to {} instances reconciles coverage with "
+                              "the other constraints ({})".format(cap, ", ".join(conflicting))))
+        total = k * instance_len
+        # Round up to complete passes of every crossing. Iterating settles on a
+        # common multiple; the iteration bound avoids chasing a large LCM when
+        # pass lengths are co-prime. crossing_size already folds in sustain.
+        passes = [block.crossing_size(c) for c in block.crossings]
+        for _ in range(4):
+            rounded = total
+            for p in passes:
+                if p > 0 and rounded % p != 0:
+                    rounded = ((rounded // p) + 1) * p
+            if rounded == total:
+                break
+            total = rounded
+        return total
 
     @staticmethod
-    def _min_instances(R_free, slots):
+    def _k_lower_bound(R_free, slots, slot_weights=None):
+        """Analytic floor for the instance count, so the matching scan can start
+        near the answer instead of at 1:
+
+        - global capacity: ceil(|R_free| / total picks per instance);
+        - Hall-style signature bounds: combos grouped by the exact set of slots
+          that can serve them; each group needs ceil(demand / group picks).
+
+        Sound but not always tight (unions of overlapping signatures are not
+        enumerated), so the matching scan remains the ground truth."""
+        if slot_weights is None:
+            slot_weights = [1] * len(slots)
+        total_picks = sum(slot_weights)
+        if total_picks <= 0:
+            return 1
+        bound = -(-len(R_free) // total_picks)  # ceil
+        demands = {}  # type: Dict[frozenset, int]
+        for c in R_free:
+            sig = frozenset(si for si, s in enumerate(slots) if c in s)
+            demands[sig] = demands.get(sig, 0) + 1
+        for sig, demand in demands.items():
+            picks = sum(slot_weights[si] for si in sig)
+            if picks > 0:
+                bound = max(bound, -(-demand // picks))  # ceil
+        return max(bound, 1)
+
+    @staticmethod
+    def _min_instances(R_free, slots, slot_weights=None):
         who = "CoverAllCombinations"
         if not R_free:
             return 1
@@ -1373,25 +1600,32 @@ class CoverAllCombinations(Constraint):
             if not any(c in s for s in slots):
                 raise ValueError((who, "combination {} cannot be produced in any free "
                                        "trial; coverage is impossible".format(c)))
+        # upper = |R_free| provably suffices: at that k, each slot's capacity
+        # already covers every combo it serves. start = the analytic floor, so
+        # the scan is guaranteed to succeed within [start, upper].
         upper = len(combos)
-        for k in range(1, upper + 1):
-            if CoverAllCombinations._feasible(combos, slots, k):
+        start = CoverAllCombinations._k_lower_bound(R_free, slots, slot_weights)
+        for k in range(start, upper + 1):
+            if CoverAllCombinations._feasible(combos, slots, k, slot_weights):
                 return k
         return upper
 
     @staticmethod
-    def _feasible(combos, slots, k):
-        """Can `combos` be covered with each slot-type covering at most `k` combos?
+    def _feasible(combos, slots, k, slot_weights=None):
+        """Can `combos` be covered with each slot-type covering at most
+        `k * weight` combos? (A weight-w cell appears w times per instance.)
 
-        Bipartite matching where each slot-type has `k` copies (capacity), via Kuhn's
-        augmenting-path algorithm. Sizes are small for experimental designs.
+        Bipartite matching where each slot-type has capacity-many copies, via
+        Kuhn's augmenting-path algorithm. Sizes are small for experimental designs.
         """
+        if slot_weights is None:
+            slot_weights = [1] * len(slots)
         adj = [[si for si, s in enumerate(slots) if c in s] for c in combos]
         slot_copy_match = {}  # type: Dict[tuple, int]
 
         def augment(ci, visited):
             for si in adj[ci]:
-                for copy in range(k):
+                for copy in range(k * slot_weights[si]):
                     key = (si, copy)
                     if key in visited:
                         continue
@@ -1409,52 +1643,32 @@ class CoverAllCombinations(Constraint):
 
     # ~~~~~~~~~~~~~~ Constraint interface ~~~~~~~~~~~~~~
 
-    def section_length(self, block) -> int:
-        """Trials per inner-block instance, used by print_experiments sectioning."""
-        return self._inner_len if self._inner_len else 0
-
     def uses_factor(self, f: Factor) -> bool:
         return any(factor.uses_factor(f) for factor in self.factors)
 
     def desugar(self, replacements: dict) -> List[Constraint]:
         factors = [replacements.get(f, [f, f])[1] for f in self.factors]
-        c = CoverAllCombinations(*factors, name=self.name)
+        c = CoverAllCombinations(*factors)
         c._inner_block = self._inner_block
-        c._inner_len = self._inner_len
         return [c]
 
     def validate(self, block: Block) -> None:
         who = "CoverAllCombinations"
-        # Check weights first (on the factor object directly): weighted factors get
-        # desugared, so a has_factor-based check would otherwise mask the real reason.
+        # Weighted levels are not supported yet (checked on the factor object directly:
+        # weighted factors get desugared, so a has_factor-based check would otherwise
+        # mask the real reason).
         for f in self.factors:
             if f.level_weight_sum() != len(f.levels):
                 raise ValueError((who, "weighted levels not currently supported"))
         for f in self.factors:
             validate_factor(block, f)
-        if self._inner_block is None:
-            raise ValueError((who, "CoverAllCombinations is only meaningful inside a Nest"))
-        # All listed factors must live in the inner block (v1 scope).
-        for f in self.factors:
-            if not self._inner_block.has_factor(f):
-                raise ValueError((who, "factor '{}' must be in the inner block".format(f.name)))
-        # Must be disjoint from any LatinSquare / Sequential on the same block: those
-        # would pin a factor the coverage model assumes free.
-        for ct in block.constraints:
-            if isinstance(ct, LatinSquare):
-                shared = [f.name for f in self.factors if f in ct.factors]
-                if shared:
-                    raise ValueError((who, "factors {} also appear in a LatinSquare "
-                                           "constraint".format(shared)))
-            if isinstance(ct, Sequential):
-                if ct.factor in self.factors:
-                    raise ValueError((who, "factor '{}' also appears in a Sequential "
-                                           "constraint".format(ct.factor.name)))
-        # Feasibility (also raises on an impossible-to-cover combination).
-        self.required_instances(self._inner_block)
+        # No coexistence guards: other constraints (LatinSquare, Sequential, Pin, ...)
+        # are reconciled into the sizing computation where statically possible, and
+        # otherwise arbitrated by the SAT solver in the joint problem.
 
     def apply(self, block: Block, backend_request: BackendRequest) -> None:
-        (_, _, R_free, _, combo_levels) = self._coverage_analysis(self._inner_block)
+        (_, _, R_free, _, combo_levels, _, _) = self._coverage_analysis(
+            self._analysis_block(block), exclusion_block=block)
         if not R_free:
             return
         preamble = block.common_preamble_size()
@@ -1479,7 +1693,8 @@ class CoverAllCombinations(Constraint):
         backend_request.fresh = new_fresh
 
     def potential_sample_conforms(self, sample: dict, block: Block) -> bool:
-        (_, _, R_free, _, _) = self._coverage_analysis(self._inner_block)
+        (_, _, R_free, _, _, _, _) = self._coverage_analysis(
+            self._analysis_block(block), exclusion_block=block)
         if not R_free:
             return True
         num_trials = block.trials_per_sample()
@@ -1495,6 +1710,5 @@ class CoverAllCombinations(Constraint):
         return True
 
     def __repr__(self):
-        return "CoverAllCombinations({}{})".format(
-            ", ".join([f.name for f in self.factors]),
-            ", name={!r}".format(self.name) if self.name else "")
+        return "CoverAllCombinations({})".format(
+            ", ".join([f.name for f in self.factors]))

--- a/sweetpea/_internal/constraint.py
+++ b/sweetpea/_internal/constraint.py
@@ -13,7 +13,7 @@ from sweetpea._internal.iter import chunk, chunk_list
 from sweetpea._internal.block import Block, BlockGeometry
 from sweetpea._internal.cross_block import MultiCrossBlockRepeat
 from sweetpea._internal.backend import LowLevelRequest, BackendRequest
-from sweetpea._internal.logic import If, Iff, And, Or, Not, Formula
+from sweetpea._internal.logic import If, Iff, And, Or, Not, Formula, FormulaWithIff
 from sweetpea._internal.primitive import DerivedFactor, DerivedLevel, Factor, Level, SimpleLevel, ContinuousFactor
 from sweetpea._internal.argcheck import argcheck, make_istuple, make_islistof
 from sweetpea._internal.weight import combination_weight
@@ -1674,7 +1674,7 @@ class CoverAllCombinations(Constraint):
         trials = list(range(1 + preamble, num_trials + 1))
 
         fresh = backend_request.fresh
-        formula_parts = cast(List[Formula], [])
+        formula_parts = cast(List[FormulaWithIff], [])
         for combo in R_free:
             levels = combo_levels[combo]
             state_vars = []

--- a/sweetpea/_internal/cross_block.py
+++ b/sweetpea/_internal/cross_block.py
@@ -91,7 +91,7 @@ class MultiCrossBlockRepeat(Block):
 
         crossings = [c for c in crossings if len(c) > 0]
 
-        from sweetpea._internal.constraint import Cross, Consistency, Sustain
+        from sweetpea._internal.constraint import Cross, Consistency, Sustain, CoverAllCombinations
         from sweetpea._internal.derivation_processor import DerivationProcessor
         self.orig_design = design
         self.orig_crossings = crossings
@@ -114,6 +114,23 @@ class MultiCrossBlockRepeat(Block):
         
         if not all([s == self.preamble_sizes[0] for s in self.preamble_sizes]) and self.alignment == AlignmentMode.EQUAL_PREAMBLE:
             raise RuntimeError("AlignmentMode.EQUAL_PREAMBLE not allowed with different preamble sizes")
+
+        # Auto-size for any CoverAllCombinations constraint: grow the trial count to
+        # the minimum needed for coverage. This runs in the shared construction path
+        # so that every construct (CrossBlock, Merge, Repeat, Nest) auto-sizes, and
+        # before trials_per_sample() is first cached.
+        for ct in self.constraints:
+            if isinstance(ct, CoverAllCombinations):
+                target = ct.autosize_trials(self)
+                if target > self.min_trials:
+                    self.min_trials = target
+                    for count in self.crossing_sustain_counts:
+                        # keep min_trials a multiple of each sustain count
+                        if (self.min_trials // count) * count != self.min_trials:
+                            self.min_trials = ((self.min_trials // count) + 1) * count
+                    # A constraint's validate() (e.g. Pin's range check) may have
+                    # already cached the pre-growth trial count; invalidate it.
+                    self._trials_per_sample = None
 
         if mode != RepeatMode.REPEAT:
             num_trials = self.trials_per_sample()
@@ -656,22 +673,12 @@ class Nest(MultiCrossBlockRepeat):
             ct.sustain_within_block(inner_len)
         all_constraints = outer_constraints + inner_constraints + constraints
 
-        # Auto-size for any CoverAllCombinations constraint: grow the number of
-        # inner-block instances to the minimum needed for coverage, rounded up to a
-        # multiple of the outer crossing size so the outer crossing stays balanced.
-        from sweetpea._internal.constraint import CoverAllCombinations, MinimumTrials
-        outer_instances = outer_block.trials_per_sample() - outer_block.common_preamble_size()
+        # Give any CoverAllCombinations constraint its inner-block context; the
+        # shared _create path performs the auto-sizing.
+        from sweetpea._internal.constraint import CoverAllCombinations
         for ct in constraints:
             if isinstance(ct, CoverAllCombinations):
                 ct._inner_block = inner_block
-                ct._inner_len = inner_len
-                # Only auto-size when the listed factors are valid inner-block factors;
-                # otherwise let _create's validate() raise a clear scope error.
-                if all(inner_block.has_factor(f) for f in ct.factors):
-                    k = ct.required_instances(inner_block)
-                    if outer_instances > 0:
-                        k = ((k + outer_instances - 1) // outer_instances) * outer_instances
-                    all_constraints = all_constraints + [MinimumTrials(k * inner_len)]
 
         self._create(
             who=who,

--- a/sweetpea/_internal/cross_block.py
+++ b/sweetpea/_internal/cross_block.py
@@ -115,10 +115,8 @@ class MultiCrossBlockRepeat(Block):
         if not all([s == self.preamble_sizes[0] for s in self.preamble_sizes]) and self.alignment == AlignmentMode.EQUAL_PREAMBLE:
             raise RuntimeError("AlignmentMode.EQUAL_PREAMBLE not allowed with different preamble sizes")
 
-        # Auto-size for any CoverAllCombinations constraint: grow the trial count to
-        # the minimum needed for coverage. This runs in the shared construction path
-        # so that every construct (CrossBlock, Merge, Repeat, Nest) auto-sizes, and
-        # before trials_per_sample() is first cached.
+        # Auto-size for CoverAllCombinations: raise the trial count to the minimum
+        # needed for coverage. Must run before trials_per_sample() is first cached.
         for ct in self.constraints:
             if isinstance(ct, CoverAllCombinations):
                 target = ct.autosize_trials(self)
@@ -673,8 +671,8 @@ class Nest(MultiCrossBlockRepeat):
             ct.sustain_within_block(inner_len)
         all_constraints = outer_constraints + inner_constraints + constraints
 
-        # Give any CoverAllCombinations constraint its inner-block context; the
-        # shared _create path performs the auto-sizing.
+        # A CoverAllCombinations constraint analyzes the inner block's crossing;
+        # _create's auto-sizing reads this.
         from sweetpea._internal.constraint import CoverAllCombinations
         for ct in constraints:
             if isinstance(ct, CoverAllCombinations):

--- a/sweetpea/_internal/cross_block.py
+++ b/sweetpea/_internal/cross_block.py
@@ -655,6 +655,24 @@ class Nest(MultiCrossBlockRepeat):
         for ct in outer_constraints:
             ct.sustain_within_block(inner_len)
         all_constraints = outer_constraints + inner_constraints + constraints
+
+        # Auto-size for any CoverAllCombinations constraint: grow the number of
+        # inner-block instances to the minimum needed for coverage, rounded up to a
+        # multiple of the outer crossing size so the outer crossing stays balanced.
+        from sweetpea._internal.constraint import CoverAllCombinations, MinimumTrials
+        outer_instances = outer_block.trials_per_sample() - outer_block.common_preamble_size()
+        for ct in constraints:
+            if isinstance(ct, CoverAllCombinations):
+                ct._inner_block = inner_block
+                ct._inner_len = inner_len
+                # Only auto-size when the listed factors are valid inner-block factors;
+                # otherwise let _create's validate() raise a clear scope error.
+                if all(inner_block.has_factor(f) for f in ct.factors):
+                    k = ct.required_instances(inner_block)
+                    if outer_instances > 0:
+                        k = ((k + outer_instances - 1) // outer_instances) * outer_instances
+                    all_constraints = all_constraints + [MinimumTrials(k * inner_len)]
+
         self._create(
             who=who,
             design=design,

--- a/sweetpea/_internal/main.py
+++ b/sweetpea/_internal/main.py
@@ -172,32 +172,22 @@ def print_experiments(block, experiments):
     # Restore continuous factors for printing trials
     block.restore_continuous()
 
-    # A LatinSquare or CoverAllCombinations constraint with a name divides each
-    # experiment's trials into labeled sections. LatinSquare diagonal labels cycle;
-    # CoverAllCombinations instance labels are sequential (0, 1, ... K-1).
-    sec_name = None
-    sec_len = 0
-    sec_cycle = False
+    ls_name = None
+    ls_dlen = 0
     for ct in block.orig_constraints:
         if isinstance(ct, LatinSquare) and ct.name:
-            sec_name = ct.name
-            sec_len = ct.diagonal_length()
-            sec_cycle = True
-        elif isinstance(ct, CoverAllCombinations) and ct.name:
-            sec_name = ct.name
-            sec_len = ct.section_length(block)
-            sec_cycle = False
+            ls_name = ct.name
+            ls_dlen = ct.diagonal_length()
 
     print('\n{} trial sequences found.\n'.format(len(experiments)))
     for idx, e in enumerate(experiments):
         print('Experiment {}:'.format(idx))
         e_len = len(e[next(iter(e))])
-        if sec_name and sec_len:
+        if ls_name:
             print('')
-            for i in range(0, e_len, sec_len):
-                label = (i // sec_len) % sec_len if sec_cycle else (i // sec_len)
-                print('{} {}:'.format(sec_name, label))
-                _print_experiment_participant(block.orig_design, e, i, min(i+sec_len, e_len))
+            for i in range(0, e_len, ls_dlen):
+                print('{} {}:'.format(ls_name, (i // ls_dlen) % ls_dlen))
+                _print_experiment_participant(block.orig_design, e, i, min(i+ls_dlen, e_len))
         else:
             _print_experiment_participant(block.orig_design, e, 0, e_len)
 
@@ -436,6 +426,24 @@ def synthesize_trials(block: Block,
             for k in continuous_samples:
                 trials[k] = continuous_samples[k]
         # Restore ContinuousFactor to the design
+
+    if not trialss:
+        # When a coverage constraint is present, an empty result usually means the
+        # SAT solver judged the joint constraints unsatisfiable. Constraints that
+        # are not folded into coverage auto-sizing (ordering constraints and
+        # LatinSquare) are the usual cause; give the user a pointer.
+        from sweetpea._internal.constraint import _KInARow
+        cacs = [ct for ct in block.orig_constraints if isinstance(ct, CoverAllCombinations)]
+        if cacs:
+            msg = ("No trial sequences found: the constraints could not be satisfied "
+                   "together with " + " and ".join(repr(ct) for ct in cacs) + ".")
+            unmodeled = sorted(set(type(ct).__name__ for ct in block.orig_constraints
+                                   if isinstance(ct, (_KInARow, LatinSquare))))
+            if unmodeled:
+                msg += (" Constraints of kind " + ", ".join(unmodeled)
+                        + " are not folded into coverage auto-sizing; a MinimumTrials"
+                          " constraint can provide additional trials.")
+            print(msg)
 
     return trialss
 

--- a/sweetpea/_internal/main.py
+++ b/sweetpea/_internal/main.py
@@ -428,10 +428,9 @@ def synthesize_trials(block: Block,
         # Restore ContinuousFactor to the design
 
     if not trialss:
-        # When a coverage constraint is present, an empty result usually means the
-        # SAT solver judged the joint constraints unsatisfiable. Constraints that
-        # are not folded into coverage auto-sizing (ordering constraints and
-        # LatinSquare) are the usual cause; give the user a pointer.
+        # With a coverage constraint, an empty result means the solver found the
+        # joint constraints unsatisfiable. Point at the constraints that coverage
+        # auto-sizing cannot account for (ordering constraints and LatinSquare).
         from sweetpea._internal.constraint import _KInARow
         cacs = [ct for ct in block.orig_constraints if isinstance(ct, CoverAllCombinations)]
         if cacs:

--- a/sweetpea/_internal/main.py
+++ b/sweetpea/_internal/main.py
@@ -22,6 +22,7 @@ __all__ = [
     'ExactlyKInARow',
     'LatinSquare',
     'Sequential',
+    'CoverAllCombinations',
 
     'Gen', 'RandomGen', 'IterateSATGen',
     'CMSGen', 'UniGen', 'IterateILPGen',
@@ -53,7 +54,8 @@ from sweetpea._internal.constraint import (
     Exclude, Pin, MinimumTrials,
     ExactlyK, AtMostKInARow, AtLeastKInARow, ExactlyKInARow,
     LatinSquare,
-    Sequential
+    Sequential,
+    CoverAllCombinations
 )
 from sweetpea._internal.sampling_strategy.base import Gen
 from sweetpea._internal.sampling_strategy.uniform import UniformGen
@@ -170,22 +172,32 @@ def print_experiments(block, experiments):
     # Restore continuous factors for printing trials
     block.restore_continuous()
 
-    ls_name = None
-    ls_dlen = 0
+    # A LatinSquare or CoverAllCombinations constraint with a name divides each
+    # experiment's trials into labeled sections. LatinSquare diagonal labels cycle;
+    # CoverAllCombinations instance labels are sequential (0, 1, ... K-1).
+    sec_name = None
+    sec_len = 0
+    sec_cycle = False
     for ct in block.orig_constraints:
         if isinstance(ct, LatinSquare) and ct.name:
-            ls_name = ct.name
-            ls_dlen = ct.diagonal_length()
+            sec_name = ct.name
+            sec_len = ct.diagonal_length()
+            sec_cycle = True
+        elif isinstance(ct, CoverAllCombinations) and ct.name:
+            sec_name = ct.name
+            sec_len = ct.section_length(block)
+            sec_cycle = False
 
     print('\n{} trial sequences found.\n'.format(len(experiments)))
     for idx, e in enumerate(experiments):
         print('Experiment {}:'.format(idx))
         e_len = len(e[next(iter(e))])
-        if ls_name:
+        if sec_name and sec_len:
             print('')
-            for i in range(0, e_len, ls_dlen):
-                print('{} {}:'.format(ls_name, (i // ls_dlen) % ls_dlen))
-                _print_experiment_participant(block.orig_design,  e, i, min(i+ls_dlen, e_len))
+            for i in range(0, e_len, sec_len):
+                label = (i // sec_len) % sec_len if sec_cycle else (i // sec_len)
+                print('{} {}:'.format(sec_name, label))
+                _print_experiment_participant(block.orig_design, e, i, min(i+sec_len, e_len))
         else:
             _print_experiment_participant(block.orig_design, e, 0, e_len)
 


### PR DESCRIPTION
Modified **CoverAllCombinations(*factors)** constraint: the trials of an experiment must collectively include every realizable combination of the listed factors, and the block auto-sizes to the minimum trial count that makes this possible.

- Generalized to work on CrossBlock, Merge, Repeat, and Nest
- Sizing = K-search over a joint model: capacitated bipartite matching over "which free cells can produce which combinations," with other constraints reconciled in (Exclude shrinks the required set; ExactlyK caps totals, with a construction-time error when provably impossible; Pin consumes capacity; Sequential modeled per-position). In-a-row and LatinSquare are left to the solver; a zero-sample result prints a hint.
- Weighted crossed levels supported

Something to note: K scan is linear by design: ExactlyK makes feasibility non-monotone in K (forced combinations repeat per pass and consume the cap), so binary search would not work; an analytic lower bound starts the scan at/near the answer.  This analytic  lower bound (K_lb) is calculated using two formulas:  (global capacity + Hall-style signature bounds).
