### PR TITLE
Add optional factors to CoverAllCombinations to allow prioritization

### DIFF
--- a/acceptance/test_cover_all_combinations.py
+++ b/acceptance/test_cover_all_combinations.py
@@ -291,7 +291,7 @@ def test_unmodeled_conflict_yields_hint(capsys):
     assert 'AtLeastKInARow' in out
 
 
-# ~~~~~~~~~~~~ Coverage/trials tradeoff (prioritize) ~~~~~~~~~~~~
+# ~~~~~~~~~~~~ Coverage/trials tradeoff (required vs optional) ~~~~~~~~~~~~
 
 def _trio():
     """`task` is crossed while colr, size, and cue ride free, so covering all
@@ -304,48 +304,52 @@ def _trio():
     return colr, size, cue, task
 
 
-def _trio_block(colr, size, cue, task, listed=None, **kw):
-    listed = listed if listed is not None else [colr, size, cue]
+def _trio_block(colr, size, cue, task, required=None, **kw):
+    """All three factors required by default, which is full coverage."""
+    required = [colr, size, cue] if required is None else required
     return CrossBlock(design=[task, colr, size, cue], crossing=[task],
-                      constraints=[CoverAllCombinations(*listed, **kw)])
+                      constraints=[CoverAllCombinations(*required, **kw)])
 
 
-@pytest.mark.parametrize('kw', [{}, {'prioritize': []}])
-def test_prioritize_empty_keeps_full_coverage(kw):
+@pytest.mark.parametrize('kw', [{}, {'optional': []}])
+def test_no_optional_keeps_full_coverage(kw):
     colr, size, cue, task = _trio()
     assert _trio_block(colr, size, cue, task, **kw).trials_per_sample() == 12
 
 
-def test_prioritize_reduces_trials():
+def test_optional_reduces_trials():
     # colr x size needs 2 passes and cue's 3 levels need 2, so K = 2.
     colr, size, cue, task = _trio()
-    block = _trio_block(colr, size, cue, task, prioritize=[colr, size])
+    block = _trio_block(colr, size, cue, task, required=[colr, size], optional=[cue])
     assert block.trials_per_sample() == 4
 
 
-def test_prioritize_every_factor_is_full_coverage():
+def test_optional_ignores_duplicates():
     colr, size, cue, task = _trio()
-    block = _trio_block(colr, size, cue, task, prioritize=[colr, size, cue])
-    assert block.trials_per_sample() == 12
-
-
-def test_prioritize_ignores_duplicates():
-    colr, size, cue, task = _trio()
-    block = _trio_block(colr, size, cue, task, prioritize=[colr, colr, size])
+    block = _trio_block(colr, size, cue, task, required=[colr, size],
+                        optional=[cue, cue])
     assert block.trials_per_sample() == 4
 
 
-def test_prioritize_demoting_crossed_factor_is_harmless():
-    # `task` is crossed, so its singleton group is satisfied by every pass.
+def test_optional_crossed_factor_is_harmless():
+    # `task` is crossed, so its group is satisfied by every pass.
     colr, size, cue, task = _trio()
-    block = _trio_block(colr, size, cue, task, listed=[task, colr, size, cue],
-                        prioritize=[colr, size])
+    block = _trio_block(colr, size, cue, task, required=[colr, size],
+                        optional=[task, cue])
     assert block.trials_per_sample() == 4
 
 
-def test_prioritize_keeps_both_guarantees():
+def test_optional_without_any_required_factors():
+    # Nothing has to be covered in combination; each cue level just has to
+    # appear, which two passes can hold.
     colr, size, cue, task = _trio()
-    block = _trio_block(colr, size, cue, task, prioritize=[colr, size])
+    block = _trio_block(colr, size, cue, task, required=[], optional=[cue])
+    assert block.trials_per_sample() == 4
+
+
+def test_optional_keeps_both_guarantees():
+    colr, size, cue, task = _trio()
+    block = _trio_block(colr, size, cue, task, required=[colr, size], optional=[cue])
     exps = synthesize_trials(block, 1, sampling_strategy=IterateGen)
     assert exps
     for e in exps:
@@ -355,7 +359,7 @@ def test_prioritize_keeps_both_guarantees():
 
 
 def test_two_coverage_constraints_take_the_larger():
-    # Two constraints express the same thing as prioritize=[colr, size].
+    # Two constraints express the same thing as optional=[cue].
     colr, size, cue, task = _trio()
     block = CrossBlock(design=[task, colr, size, cue], crossing=[task],
                        constraints=[CoverAllCombinations(colr, size),
@@ -369,27 +373,32 @@ def test_two_coverage_constraints_take_the_larger():
         assert set(e['cue']) == {'c1', 'c2', 'c3'}
 
 
-def test_prioritize_unknown_factor_raises():
+def test_factor_cannot_be_required_and_optional():
     colr, size, cue, task = _trio()
+    with pytest.raises(ValueError, match='both required and optional'):
+        CoverAllCombinations(colr, size, optional=[size])
+
+
+def test_no_factors_at_all_raises():
     with pytest.raises(ValueError):
-        CoverAllCombinations(colr, size, prioritize=[cue])
+        CoverAllCombinations()
 
 
-def test_prioritize_rejects_a_bool():
+def test_optional_rejects_a_bool():
     colr, size, cue, task = _trio()
-    with pytest.raises(ValueError, match='prioritize'):
-        CoverAllCombinations(colr, size, cue, prioritize=True)
+    with pytest.raises(ValueError, match='optional'):
+        CoverAllCombinations(colr, size, cue, optional=True)
 
 
-def test_prioritize_repr_shows_the_choice():
+def test_repr_shows_the_groups():
     colr, size, cue, task = _trio()
-    assert repr(CoverAllCombinations(colr, size, cue, prioritize=[colr, size])) == \
-        'CoverAllCombinations(colr, size, cue, prioritize=[colr, size])'
-    assert repr(CoverAllCombinations(colr, size, cue)) == \
-        'CoverAllCombinations(colr, size, cue)'
+    assert (repr(CoverAllCombinations(colr, size, optional=[cue]))
+            == 'CoverAllCombinations(colr, size, optional=[cue])')
+    assert (repr(CoverAllCombinations(colr, size, cue))
+            == 'CoverAllCombinations(colr, size, cue)')
 
 
-def test_prioritize_in_nest():
+def test_optional_in_nest():
     colors, color, word, congruency, _ = _stroop(3)
     cue = Factor('cue', ['c1', 'c2', 'c3', 'c4'])
     inner = CrossBlock([congruency, color, word, cue], [congruency, color], [])
@@ -399,20 +408,19 @@ def test_prioritize_in_nest():
     # own 8 word-cue combinations, so K = 8 over passes of 6.
     full = Nest(outer, inner, [CoverAllCombinations(color, word, cue)])
     assert full.trials_per_sample() == 48
-    # Demoting cue leaves the 6 free color-word pairs over 3 slots: K = 2.
+    # Making cue optional leaves the 6 free color-word pairs over 3 slots: K = 2.
     fewer = Nest(outer, inner,
-                 [CoverAllCombinations(color, word, cue, prioritize=[color, word])])
+                 [CoverAllCombinations(color, word, optional=[cue])])
     assert fewer.trials_per_sample() == 12
 
 
-def test_prioritize_with_weighted_crossing():
+def test_optional_with_weighted_crossing():
     # Weighted levels on the crossed factor still size correctly once some of
-    # the listed factors are demoted.
+    # the governed factors are optional.
     colors, color, word, congruency = _stroop_weighted(4, 2)
     cue = Factor('cue', ['c1', 'c2', 'c3'])
     block = CrossBlock([congruency, color, word, cue], [congruency, color],
-                       [CoverAllCombinations(color, word, cue,
-                                             prioritize=[color, word])])
+                       [CoverAllCombinations(color, word, optional=[cue])])
     exps = synthesize_trials(block, 1, sampling_strategy=IterateGen)
     assert exps
     for e in exps:
@@ -427,23 +435,21 @@ def test_reports_the_count_under_full_coverage(capsys):
     _trio_block(colr, size, cue, task)
     out = capsys.readouterr().out
     assert 'CoverAllCombinations(colr, size, cue) requires 12 trials.' in out
-    # Nothing was demoted, so nothing is said about individual levels.
+    # Nothing is optional, so nothing is said about individual levels.
     assert 'each level appears' not in out
 
 
-def test_reports_the_count_and_demotions_under_prioritize(capsys):
+def test_reports_the_count_and_optional_factors(capsys):
     colr, size, cue, task = _trio()
-    _trio_block(colr, size, cue, task, prioritize=[colr, size])
+    _trio_block(colr, size, cue, task, required=[colr, size], optional=[cue])
     out = capsys.readouterr().out
-    assert ('CoverAllCombinations(colr, size, cue, prioritize=[colr, size]) '
-            'requires 4 trials. (cue: each level appears at least once)') in out
+    assert ('CoverAllCombinations(colr, size, optional=[cue]) requires 4 trials. '
+            '(cue: each level appears at least once)') in out
 
 
-def test_reports_demotions_for_a_single_prioritized_factor(capsys):
-    # Every group is a singleton here, so group size cannot tell the kept
-    # factor from the demoted ones; the report comes from `prioritize`.
+def test_reports_every_optional_factor(capsys):
     colr, size, cue, task = _trio()
-    _trio_block(colr, size, cue, task, prioritize=[colr])
+    _trio_block(colr, size, cue, task, required=[colr], optional=[size, cue])
     out = capsys.readouterr().out
     assert '(size, cue: each level appears at least once)' in out
 

--- a/acceptance/test_cover_all_combinations.py
+++ b/acceptance/test_cover_all_combinations.py
@@ -222,7 +222,7 @@ def test_k_lower_bound_tight_for_stroop(n, expected_k):
     # matching scan does a single confirming check.
     _, color, word, _, inner = _stroop(n)
     cac = CoverAllCombinations(color, word)
-    (_, _, R_free, slots, _, sw, _) = cac._coverage_analysis(inner)
+    (_, _, R_free, slots, _, sw, _) = cac._coverage_analysis(inner, [color, word])
     assert cac._k_lower_bound(R_free, slots, sw) == expected_k
     assert cac.required_instances(inner) == expected_k
 
@@ -289,6 +289,201 @@ def test_unmodeled_conflict_yields_hint(capsys):
     out = capsys.readouterr().out
     assert 'CoverAllCombinations' in out
     assert 'AtLeastKInARow' in out
+
+
+# ~~~~~~~~~~~~ Coverage/trials tradeoff (prioritize) ~~~~~~~~~~~~
+
+def _trio():
+    """`task` is crossed while colr, size, and cue ride free, so covering all
+    three together is what drives the trial count: 2*2*3 = 12 combinations over
+    2 free slots per pass, hence 12 trials."""
+    colr = Factor('colr', ['red', 'green'])
+    size = Factor('size', ['big', 'small'])
+    cue = Factor('cue', ['c1', 'c2', 'c3'])
+    task = Factor('task', ['A', 'B'])
+    return colr, size, cue, task
+
+
+def _trio_block(colr, size, cue, task, listed=None, **kw):
+    listed = listed if listed is not None else [colr, size, cue]
+    return CrossBlock(design=[task, colr, size, cue], crossing=[task],
+                      constraints=[CoverAllCombinations(*listed, **kw)])
+
+
+class _Answers:
+    """Stands in for `input`, replaying scripted answers and recording the
+    prompts it was asked."""
+
+    def __init__(self, *answers):
+        self.answers = list(answers)
+        self.prompts = []
+
+    def __call__(self, prompt=''):
+        self.prompts.append(prompt)
+        if not self.answers:
+            raise AssertionError('unexpected extra prompt: {}'.format(prompt))
+        return self.answers.pop(0)
+
+
+@pytest.mark.parametrize('kw', [{}, {'prioritize': False}])
+def test_prioritize_off_keeps_full_coverage(kw):
+    colr, size, cue, task = _trio()
+    assert _trio_block(colr, size, cue, task, **kw).trials_per_sample() == 12
+
+
+def test_prioritize_reduces_trials():
+    # colr x size needs 2 passes and cue's 3 levels need 2, so K = 2.
+    colr, size, cue, task = _trio()
+    block = _trio_block(colr, size, cue, task, prioritize=[colr, size])
+    assert block.trials_per_sample() == 4
+
+
+def test_prioritize_every_factor_is_full_coverage():
+    colr, size, cue, task = _trio()
+    block = _trio_block(colr, size, cue, task, prioritize=[colr, size, cue])
+    assert block.trials_per_sample() == 12
+
+
+def test_prioritize_empty_demotes_everything():
+    colr, size, cue, task = _trio()
+    block = _trio_block(colr, size, cue, task, prioritize=[])
+    assert block.trials_per_sample() == 4
+
+
+def test_prioritize_ignores_duplicates():
+    colr, size, cue, task = _trio()
+    block = _trio_block(colr, size, cue, task, prioritize=[colr, colr, size])
+    assert block.trials_per_sample() == 4
+
+
+def test_prioritize_demoting_crossed_factor_is_harmless():
+    # `task` is crossed, so its singleton group is satisfied by every pass.
+    colr, size, cue, task = _trio()
+    block = _trio_block(colr, size, cue, task, listed=[task, colr, size, cue],
+                        prioritize=[colr, size])
+    assert block.trials_per_sample() == 4
+
+
+def test_prioritize_keeps_both_guarantees():
+    colr, size, cue, task = _trio()
+    block = _trio_block(colr, size, cue, task, prioritize=[colr, size])
+    exps = synthesize_trials(block, 1, sampling_strategy=IterateGen)
+    assert exps
+    for e in exps:
+        assert set(zip(e['colr'], e['size'])) == set(
+            (c, s) for c in ['red', 'green'] for s in ['big', 'small'])
+        assert set(e['cue']) == {'c1', 'c2', 'c3'}
+
+
+def test_two_coverage_constraints_take_the_larger():
+    # Two constraints express the same thing as prioritize=[colr, size].
+    colr, size, cue, task = _trio()
+    block = CrossBlock(design=[task, colr, size, cue], crossing=[task],
+                       constraints=[CoverAllCombinations(colr, size),
+                                    CoverAllCombinations(cue)])
+    assert block.trials_per_sample() == 4
+    exps = synthesize_trials(block, 1, sampling_strategy=IterateGen)
+    assert exps
+    for e in exps:
+        assert set(zip(e['colr'], e['size'])) == set(
+            (c, s) for c in ['red', 'green'] for s in ['big', 'small'])
+        assert set(e['cue']) == {'c1', 'c2', 'c3'}
+
+
+def test_prioritize_unknown_factor_raises():
+    colr, size, cue, task = _trio()
+    with pytest.raises(ValueError):
+        CoverAllCombinations(colr, size, prioritize=[cue])
+
+
+def test_prioritize_repr_shows_the_choice():
+    colr, size, cue, task = _trio()
+    assert repr(CoverAllCombinations(colr, size, cue, prioritize=[colr, size])) == \
+        'CoverAllCombinations(colr, size, cue, prioritize=[colr, size])'
+    assert repr(CoverAllCombinations(colr, size, cue, prioritize=True)) == \
+        'CoverAllCombinations(colr, size, cue, prioritize=True)'
+
+
+def test_prioritize_in_nest():
+    colors, color, word, congruency, _ = _stroop(3)
+    cue = Factor('cue', ['c1', 'c2', 'c3', 'c4'])
+    inner = CrossBlock([congruency, color, word, cue], [congruency, color], [])
+    instance = Factor('instance', ['a', 'b'])
+    outer = CrossBlock([instance], [instance], [])
+    # Full coverage: each incongruent cell is the only one that can serve its
+    # own 8 word-cue combinations, so K = 8 over passes of 6.
+    full = Nest(outer, inner, [CoverAllCombinations(color, word, cue)])
+    assert full.trials_per_sample() == 48
+    # Demoting cue leaves the 6 free color-word pairs over 3 slots: K = 2.
+    fewer = Nest(outer, inner,
+                 [CoverAllCombinations(color, word, cue, prioritize=[color, word])])
+    assert fewer.trials_per_sample() == 12
+
+
+def test_prioritize_with_weighted_crossing():
+    # Weighted levels on the crossed factor still size correctly once some of
+    # the listed factors are demoted.
+    colors, color, word, congruency = _stroop_weighted(4, 2)
+    cue = Factor('cue', ['c1', 'c2', 'c3'])
+    block = CrossBlock([congruency, color, word, cue], [congruency, color],
+                       [CoverAllCombinations(color, word, cue,
+                                             prioritize=[color, word])])
+    exps = synthesize_trials(block, 1, sampling_strategy=IterateGen)
+    assert exps
+    for e in exps:
+        assert _covers_all(e, colors)
+        assert set(e['cue']) == {'c1', 'c2', 'c3'}
+
+
+# ~~~~~~~~~~~~ Interactive negotiation ~~~~~~~~~~~~
+
+def test_interactive_accepting_the_offer_changes_nothing(monkeypatch):
+    colr, size, cue, task = _trio()
+    answers = _Answers('y')
+    monkeypatch.setattr('builtins.input', answers)
+    block = _trio_block(colr, size, cue, task, prioritize=True)
+    assert block.trials_per_sample() == 12
+    assert '12 trials' in answers.prompts[0]
+
+
+def test_interactive_declining_then_choosing(monkeypatch, capsys):
+    colr, size, cue, task = _trio()
+    monkeypatch.setattr('builtins.input', _Answers('n', 'colr, size', 'y'))
+    block = _trio_block(colr, size, cue, task, prioritize=True)
+    assert block.trials_per_sample() == 4
+    out = capsys.readouterr().out
+    assert 'That gives 4 trials' in out
+    assert 'cue' in out
+    # The session has to be reproducible without the prompt.
+    assert 'prioritize=[colr, size]' in out
+
+
+def test_interactive_reprompts_on_unknown_factor(monkeypatch, capsys):
+    colr, size, cue, task = _trio()
+    monkeypatch.setattr('builtins.input', _Answers('n', 'task', 'colr, size', 'y'))
+    block = _trio_block(colr, size, cue, task, prioritize=True)
+    assert block.trials_per_sample() == 4
+    assert 'Not listed in this constraint: task' in capsys.readouterr().out
+
+
+def test_interactive_single_factor_skips_the_prompt(monkeypatch):
+    # Nothing to demote, so the user is never asked.
+    colr, size, cue, task = _trio()
+    monkeypatch.setattr('builtins.input', _Answers())
+    block = _trio_block(colr, size, cue, task, listed=[cue], prioritize=True)
+    assert block.trials_per_sample() == 4
+
+
+def test_prioritize_without_interactive_input_warns(monkeypatch):
+    colr, size, cue, task = _trio()
+
+    def _no_input(prompt=''):
+        raise OSError('reading from stdin while output is captured')
+
+    monkeypatch.setattr('builtins.input', _no_input)
+    with pytest.warns(UserWarning, match='no interactive input'):
+        block = _trio_block(colr, size, cue, task, prioritize=True)
+    assert block.trials_per_sample() == 12
 
 
 # ~~~~~~~~~~~~ Validation errors ~~~~~~~~~~~~

--- a/acceptance/test_cover_all_combinations.py
+++ b/acceptance/test_cover_all_combinations.py
@@ -310,23 +310,8 @@ def _trio_block(colr, size, cue, task, listed=None, **kw):
                       constraints=[CoverAllCombinations(*listed, **kw)])
 
 
-class _Answers:
-    """Stands in for `input`, replaying scripted answers and recording the
-    prompts it was asked."""
-
-    def __init__(self, *answers):
-        self.answers = list(answers)
-        self.prompts = []
-
-    def __call__(self, prompt=''):
-        self.prompts.append(prompt)
-        if not self.answers:
-            raise AssertionError('unexpected extra prompt: {}'.format(prompt))
-        return self.answers.pop(0)
-
-
-@pytest.mark.parametrize('kw', [{}, {'prioritize': False}])
-def test_prioritize_off_keeps_full_coverage(kw):
+@pytest.mark.parametrize('kw', [{}, {'prioritize': []}])
+def test_prioritize_empty_keeps_full_coverage(kw):
     colr, size, cue, task = _trio()
     assert _trio_block(colr, size, cue, task, **kw).trials_per_sample() == 12
 
@@ -342,12 +327,6 @@ def test_prioritize_every_factor_is_full_coverage():
     colr, size, cue, task = _trio()
     block = _trio_block(colr, size, cue, task, prioritize=[colr, size, cue])
     assert block.trials_per_sample() == 12
-
-
-def test_prioritize_empty_demotes_everything():
-    colr, size, cue, task = _trio()
-    block = _trio_block(colr, size, cue, task, prioritize=[])
-    assert block.trials_per_sample() == 4
 
 
 def test_prioritize_ignores_duplicates():
@@ -396,12 +375,18 @@ def test_prioritize_unknown_factor_raises():
         CoverAllCombinations(colr, size, prioritize=[cue])
 
 
+def test_prioritize_rejects_a_bool():
+    colr, size, cue, task = _trio()
+    with pytest.raises(ValueError, match='prioritize'):
+        CoverAllCombinations(colr, size, cue, prioritize=True)
+
+
 def test_prioritize_repr_shows_the_choice():
     colr, size, cue, task = _trio()
     assert repr(CoverAllCombinations(colr, size, cue, prioritize=[colr, size])) == \
         'CoverAllCombinations(colr, size, cue, prioritize=[colr, size])'
-    assert repr(CoverAllCombinations(colr, size, cue, prioritize=True)) == \
-        'CoverAllCombinations(colr, size, cue, prioritize=True)'
+    assert repr(CoverAllCombinations(colr, size, cue)) == \
+        'CoverAllCombinations(colr, size, cue)'
 
 
 def test_prioritize_in_nest():
@@ -435,55 +420,42 @@ def test_prioritize_with_weighted_crossing():
         assert set(e['cue']) == {'c1', 'c2', 'c3'}
 
 
-# ~~~~~~~~~~~~ Interactive negotiation ~~~~~~~~~~~~
+# ~~~~~~~~~~~~ Reporting the trial count ~~~~~~~~~~~~
 
-def test_interactive_accepting_the_offer_changes_nothing(monkeypatch):
+def test_reports_the_count_under_full_coverage(capsys):
     colr, size, cue, task = _trio()
-    answers = _Answers('y')
-    monkeypatch.setattr('builtins.input', answers)
-    block = _trio_block(colr, size, cue, task, prioritize=True)
-    assert block.trials_per_sample() == 12
-    assert '12 trials' in answers.prompts[0]
-
-
-def test_interactive_declining_then_choosing(monkeypatch, capsys):
-    colr, size, cue, task = _trio()
-    monkeypatch.setattr('builtins.input', _Answers('n', 'colr, size', 'y'))
-    block = _trio_block(colr, size, cue, task, prioritize=True)
-    assert block.trials_per_sample() == 4
+    _trio_block(colr, size, cue, task)
     out = capsys.readouterr().out
-    assert 'That gives 4 trials' in out
-    assert 'cue' in out
-    # The session has to be reproducible without the prompt.
-    assert 'prioritize=[colr, size]' in out
+    assert 'CoverAllCombinations(colr, size, cue) requires 12 trials.' in out
+    # Nothing was demoted, so nothing is said about individual levels.
+    assert 'each level appears' not in out
 
 
-def test_interactive_reprompts_on_unknown_factor(monkeypatch, capsys):
+def test_reports_the_count_and_demotions_under_prioritize(capsys):
     colr, size, cue, task = _trio()
-    monkeypatch.setattr('builtins.input', _Answers('n', 'task', 'colr, size', 'y'))
-    block = _trio_block(colr, size, cue, task, prioritize=True)
-    assert block.trials_per_sample() == 4
-    assert 'Not listed in this constraint: task' in capsys.readouterr().out
+    _trio_block(colr, size, cue, task, prioritize=[colr, size])
+    out = capsys.readouterr().out
+    assert ('CoverAllCombinations(colr, size, cue, prioritize=[colr, size]) '
+            'requires 4 trials. (cue: each level appears at least once)') in out
 
 
-def test_interactive_single_factor_skips_the_prompt(monkeypatch):
-    # Nothing to demote, so the user is never asked.
+def test_reports_demotions_for_a_single_prioritized_factor(capsys):
+    # Every group is a singleton here, so group size cannot tell the kept
+    # factor from the demoted ones; the report comes from `prioritize`.
     colr, size, cue, task = _trio()
-    monkeypatch.setattr('builtins.input', _Answers())
-    block = _trio_block(colr, size, cue, task, listed=[cue], prioritize=True)
-    assert block.trials_per_sample() == 4
+    _trio_block(colr, size, cue, task, prioritize=[colr])
+    out = capsys.readouterr().out
+    assert '(size, cue: each level appears at least once)' in out
 
 
-def test_prioritize_without_interactive_input_warns(monkeypatch):
+def test_reports_each_constraint_separately(capsys):
     colr, size, cue, task = _trio()
-
-    def _no_input(prompt=''):
-        raise OSError('reading from stdin while output is captured')
-
-    monkeypatch.setattr('builtins.input', _no_input)
-    with pytest.warns(UserWarning, match='no interactive input'):
-        block = _trio_block(colr, size, cue, task, prioritize=True)
-    assert block.trials_per_sample() == 12
+    CrossBlock(design=[task, colr, size, cue], crossing=[task],
+               constraints=[CoverAllCombinations(colr, size),
+                            CoverAllCombinations(cue)])
+    out = capsys.readouterr().out
+    assert 'CoverAllCombinations(colr, size) requires' in out
+    assert 'CoverAllCombinations(cue) requires' in out
 
 
 # ~~~~~~~~~~~~ Validation errors ~~~~~~~~~~~~

--- a/docs/_source/api/constraints.rst
+++ b/docs/_source/api/constraints.rst
@@ -142,13 +142,13 @@ Constraints
               :type factors: List[Factor]
               :rtype: Constraint
 
-.. class:: sweetpea.CoverAllCombinations(*factors, prioritize=[])
+.. class:: sweetpea.CoverAllCombinations(*factors, optional=[])
 
               Constrains an experiment so that its trials collectively
               include every realizable combination of the levels of
-              `factors` at least once, or a weaker requirement where
-              `prioritize` names only some of them. A factor that is
-              left out of a crossing is otherwise assigned freely by the
+              `factors` at least once, plus a weaker requirement for
+              each factor named in `optional`. A factor that is left
+              out of a crossing is otherwise assigned freely by the
               solver, so nothing normally guarantees that a particular
               combination ever appears; this constraint coordinates
               those free choices.
@@ -176,32 +176,28 @@ Constraints
               weighted levels elsewhere in the crossing are supported,
               and they change the trial count accordingly.
 
-              The two arguments do different jobs: `factors` sets what
-              the constraint governs, and `prioritize` sets how
-              strongly. A factor named in `prioritize` must appear in
-              combination with the others named there; a factor left out
-              of it needs only each of its own levels to appear
-              somewhere, in no particular combination. Naming none of
-              them---the default---requires every combination of
-              `factors`. Since the required set is the product of the
-              levels involved, naming a subset trades coverage for a
-              shorter experiment.
+              The two groups carry different guarantees. The
+              positional `factors` must appear in combination with one
+              another---every combination of their levels. A factor
+              named in `optional` needs only each of its own levels to
+              appear somewhere, in no particular combination. Since the
+              required set is the product of the levels involved,
+              moving a factor to `optional` trades coverage for a
+              shorter experiment. A factor may not be in both groups.
 
               The number of trials required is printed as the block is
-              built, along with any factors that were demoted.
+              built, along with any factors that were made optional.
 
               See :ref:`Covering All Combinations <covering-all-combinations>`
               for more information.
 
-              :param factors: the factors this constraint governs; any
-                              factor not listed here is unaffected by it
+              :param factors: the factors that must appear in
+                              combination with one another
               :type factors: Factor
-              :param prioritize: which of `factors` must appear in
-                                 combination with one another; those left
-                                 out need only each of their own levels to
-                                 appear. Empty requires every combination
-                                 of `factors`.
-              :type prioritize: List[Factor]
+              :param optional: further factors the constraint governs,
+                               each needing only its own levels to
+                               appear rather than its combinations
+              :type optional: List[Factor]
               :rtype: Constraint
 
 .. class:: sweetpea.ContinuousConstraint(factors, predicate)

--- a/docs/_source/api/constraints.rst
+++ b/docs/_source/api/constraints.rst
@@ -142,7 +142,7 @@ Constraints
               :type factors: List[Factor]
               :rtype: Constraint
 
-.. class:: sweetpea.CoverAllCombinations(*factors)
+.. class:: sweetpea.CoverAllCombinations(*factors, prioritize=False)
 
               Constrains an experiment so that its trials collectively
               include every realizable combination of the levels of
@@ -175,11 +175,25 @@ Constraints
               weighted levels elsewhere in the crossing are supported,
               and they change the trial count accordingly.
 
+              Since the combinations to cover are the product of the
+              listed factors' levels, `prioritize` trades coverage for
+              a shorter experiment. Given a list of the listed factors,
+              those stay fully crossed, while each remaining factor is
+              demoted to needing only each of its own levels present.
+              Passing ``True`` instead reports the trial count as the
+              block is built and asks which factors to keep; where no
+              interactive input is available, that prompt is skipped
+              with a warning and the full count is used.
+
               See :ref:`Covering All Combinations <covering-all-combinations>`
               for more information.
 
               :param factors: the factors whose level combinations must all appear
               :type factors: Factor
+              :param prioritize: the factors to keep fully crossed, or a
+                                 boolean selecting full coverage or an
+                                 interactive choice
+              :type prioritize: Union[bool, List[Factor]]
               :rtype: Constraint
 
 .. class:: sweetpea.ContinuousConstraint(factors, predicate)

--- a/docs/_source/api/constraints.rst
+++ b/docs/_source/api/constraints.rst
@@ -142,15 +142,16 @@ Constraints
               :type factors: List[Factor]
               :rtype: Constraint
 
-.. class:: sweetpea.CoverAllCombinations(*factors, prioritize=False)
+.. class:: sweetpea.CoverAllCombinations(*factors, prioritize=[])
 
               Constrains an experiment so that its trials collectively
               include every realizable combination of the levels of
-              `factors` at least once. A factor that is left out of a
-              crossing is otherwise assigned freely by the solver, so
-              nothing normally guarantees that a particular combination
-              ever appears; this constraint coordinates those free
-              choices.
+              `factors` at least once, or a weaker requirement where
+              `prioritize` names only some of them. A factor that is
+              left out of a crossing is otherwise assigned freely by the
+              solver, so nothing normally guarantees that a particular
+              combination ever appears; this constraint coordinates
+              those free choices.
 
               Unlike most constraints, :class:`CoverAllCombinations`
               can increase the number of trials: the count needed for
@@ -175,25 +176,32 @@ Constraints
               weighted levels elsewhere in the crossing are supported,
               and they change the trial count accordingly.
 
-              Since the combinations to cover are the product of the
-              listed factors' levels, `prioritize` trades coverage for
-              a shorter experiment. Given a list of the listed factors,
-              those stay fully crossed, while each remaining factor is
-              demoted to needing only each of its own levels present.
-              Passing ``True`` instead reports the trial count as the
-              block is built and asks which factors to keep; where no
-              interactive input is available, that prompt is skipped
-              with a warning and the full count is used.
+              The two arguments do different jobs: `factors` sets what
+              the constraint governs, and `prioritize` sets how
+              strongly. A factor named in `prioritize` must appear in
+              combination with the others named there; a factor left out
+              of it needs only each of its own levels to appear
+              somewhere, in no particular combination. Naming none of
+              them---the default---requires every combination of
+              `factors`. Since the required set is the product of the
+              levels involved, naming a subset trades coverage for a
+              shorter experiment.
+
+              The number of trials required is printed as the block is
+              built, along with any factors that were demoted.
 
               See :ref:`Covering All Combinations <covering-all-combinations>`
               for more information.
 
-              :param factors: the factors whose level combinations must all appear
+              :param factors: the factors this constraint governs; any
+                              factor not listed here is unaffected by it
               :type factors: Factor
-              :param prioritize: the factors to keep fully crossed, or a
-                                 boolean selecting full coverage or an
-                                 interactive choice
-              :type prioritize: Union[bool, List[Factor]]
+              :param prioritize: which of `factors` must appear in
+                                 combination with one another; those left
+                                 out need only each of their own levels to
+                                 appear. Empty requires every combination
+                                 of `factors`.
+              :type prioritize: List[Factor]
               :rtype: Constraint
 
 .. class:: sweetpea.ContinuousConstraint(factors, predicate)

--- a/docs/_source/guide/usage.rst
+++ b/docs/_source/guide/usage.rst
@@ -1316,3 +1316,79 @@ and coverage takes that into account when sizing the block. The levels
 of the factors listed in :class:`.CoverAllCombinations` itself must be
 unweighted, however, since the meaning of a weight on a covered
 combination is not currently defined.
+
+Trading Coverage for Fewer Trials
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The set of combinations to cover is the product of the levels of the
+listed factors, so each factor added to
+:class:`.CoverAllCombinations` multiplies the trial count. Covering
+`colr`, `size`, and `cue` together takes twelve trials.
+
+  .. doctest::
+
+    >>> from sweetpea import Factor, CrossBlock, CoverAllCombinations
+    >>> colr = Factor("colr", ["red", "green"])
+    >>> size = Factor("size", ["big", "small"])
+    >>> cue = Factor("cue", ["c1", "c2", "c3"])
+    >>> task = Factor("task", ["A", "B"])
+    >>> design = [task, colr, size, cue]
+    >>> tb = CrossBlock(design=design, crossing=[task],
+    ...                 constraints=[CoverAllCombinations(colr, size, cue)])
+    >>> tb.trials_per_sample()
+    12
+
+The `prioritize` argument names the factors to keep fully crossed. The
+remaining listed factors are demoted: each of their levels must still
+appear at least once, but their combinations with the other factors
+are no longer required. Keeping `colr` and `size` crossed brings the
+same design down to four trials.
+
+  .. doctest::
+
+    >>> pb = CrossBlock(design=design, crossing=[task],
+    ...                 constraints=[CoverAllCombinations(colr, size, cue,
+    ...                                                   prioritize=[colr, size])])
+    >>> pb.trials_per_sample()
+    4
+
+All four `colr`-`size` combinations still appear and all three `cue`
+levels still appear, but the twelve three-way combinations no longer
+have to.
+
+Passing ``prioritize=True`` asks for that choice while the block is
+being built. SweetPea reports the trial count, and if it is declined,
+asks which factors to keep and reports the new count.
+
+  .. code-block:: text
+
+    CoverAllCombinations(colr, size, cue, prioritize=True) needs 12 trials.
+    Accept? [Y/n] n
+    Which factors should stay fully crossed?
+    (comma-separated, from: colr, size, cue)
+    > colr, size
+    That gives 4 trials. (cue: each level appears at least once)
+
+    CoverAllCombinations(colr, size, cue, prioritize=True) needs 4 trials.
+    Accept? [Y/n] y
+
+    To skip this prompt next time:
+        CoverAllCombinations(colr, size, cue, prioritize=[colr, size])
+
+The prompt ends by printing the equivalent `prioritize` list, because a
+script that asks a question otherwise produces a different design
+depending on what was typed. Where no interactive input is
+available---under a test runner, or a piped script---the prompt is
+skipped with a warning and the full coverage count is used.
+
+Listing the same factors in two separate constraints expresses the
+same thing without the `prioritize` argument, since each constraint is
+sized on its own and the block takes the larger count.
+
+  .. doctest::
+
+    >>> sb = CrossBlock(design=design, crossing=[task],
+    ...                 constraints=[CoverAllCombinations(colr, size),
+    ...                              CoverAllCombinations(cue)])
+    >>> sb.trials_per_sample()
+    4

--- a/docs/_source/guide/usage.rst
+++ b/docs/_source/guide/usage.rst
@@ -1129,6 +1129,7 @@ cannot hold four combinations, so the block grows to four trials.
 
     >>> cb = CrossBlock(design=[task, colr, size], crossing=[task],
     ...                 constraints=[CoverAllCombinations(colr, size)])
+    CoverAllCombinations(colr, size) requires 4 trials.
     >>> cb.trials_per_sample()
     4
 
@@ -1164,6 +1165,7 @@ passes---nine trials---are required.
     >>> word  = Factor("word",  ["red", "green", "blue"])
     >>> b = CrossBlock(design=[color, word], crossing=[color],
     ...                constraints=[CoverAllCombinations(color, word)])
+    CoverAllCombinations(color, word) requires 9 trials.
     >>> b.trials_per_sample()
     9
 
@@ -1195,6 +1197,7 @@ ruling out one `word` level leaves six combinations and six trials.
     >>> eb = CrossBlock(design=[color, word], crossing=[color],
     ...                 constraints=[CoverAllCombinations(color, word),
     ...                              Exclude((word, "red"))])
+    CoverAllCombinations(color, word) requires 6 trials.
     >>> eb.trials_per_sample()
     6
 
@@ -1221,6 +1224,7 @@ passes.
     ...                    constraints=[])
     >>> nb = Nest(outer_block=outer, inner_block=inner,
     ...           constraints=[CoverAllCombinations(color, word)])
+    CoverAllCombinations(color, word) requires 12 trials.
     >>> nb.trials_per_sample()
     12
 
@@ -1266,6 +1270,7 @@ the block up to a fourth pass.
     >>> pb = CrossBlock(design=[color, word], crossing=[color],
     ...                 constraints=[CoverAllCombinations(color, word),
     ...                              Pin(0, (word, "red"))])
+    CoverAllCombinations(color, word) requires 12 trials.
     >>> pb.trials_per_sample()
     12
 
@@ -1323,7 +1328,8 @@ Trading Coverage for Fewer Trials
 The set of combinations to cover is the product of the levels of the
 listed factors, so each factor added to
 :class:`.CoverAllCombinations` multiplies the trial count. Covering
-`colr`, `size`, and `cue` together takes twelve trials.
+`colr`, `size`, and `cue` together takes twelve trials. The count is
+reported as the block is built, so it is visible without asking for it.
 
   .. doctest::
 
@@ -1335,6 +1341,7 @@ listed factors, so each factor added to
     >>> design = [task, colr, size, cue]
     >>> tb = CrossBlock(design=design, crossing=[task],
     ...                 constraints=[CoverAllCombinations(colr, size, cue)])
+    CoverAllCombinations(colr, size, cue) requires 12 trials.
     >>> tb.trials_per_sample()
     12
 
@@ -1342,44 +1349,21 @@ The `prioritize` argument names the factors to keep fully crossed. The
 remaining listed factors are demoted: each of their levels must still
 appear at least once, but their combinations with the other factors
 are no longer required. Keeping `colr` and `size` crossed brings the
-same design down to four trials.
+same design down to four trials, and the report names what was demoted.
 
   .. doctest::
 
     >>> pb = CrossBlock(design=design, crossing=[task],
     ...                 constraints=[CoverAllCombinations(colr, size, cue,
     ...                                                   prioritize=[colr, size])])
+    CoverAllCombinations(colr, size, cue, prioritize=[colr, size]) requires 4 trials. (cue: each level appears at least once)
     >>> pb.trials_per_sample()
     4
 
 All four `colr`-`size` combinations still appear and all three `cue`
 levels still appear, but the twelve three-way combinations no longer
-have to.
-
-Passing ``prioritize=True`` asks for that choice while the block is
-being built. SweetPea reports the trial count, and if it is declined,
-asks which factors to keep and reports the new count.
-
-  .. code-block:: text
-
-    CoverAllCombinations(colr, size, cue, prioritize=True) needs 12 trials.
-    Accept? [Y/n] n
-    Which factors should stay fully crossed?
-    (comma-separated, from: colr, size, cue)
-    > colr, size
-    That gives 4 trials. (cue: each level appears at least once)
-
-    CoverAllCombinations(colr, size, cue, prioritize=True) needs 4 trials.
-    Accept? [Y/n] y
-
-    To skip this prompt next time:
-        CoverAllCombinations(colr, size, cue, prioritize=[colr, size])
-
-The prompt ends by printing the equivalent `prioritize` list, because a
-script that asks a question otherwise produces a different design
-depending on what was typed. Where no interactive input is
-available---under a test runner, or a piped script---the prompt is
-skipped with a warning and the full coverage count is used.
+have to. To choose differently, change the `prioritize` list and build
+the block again.
 
 Listing the same factors in two separate constraints expresses the
 same thing without the `prioritize` argument, since each constraint is
@@ -1390,5 +1374,7 @@ sized on its own and the block takes the larger count.
     >>> sb = CrossBlock(design=design, crossing=[task],
     ...                 constraints=[CoverAllCombinations(colr, size),
     ...                              CoverAllCombinations(cue)])
+    CoverAllCombinations(colr, size) requires 4 trials.
+    CoverAllCombinations(cue) requires 4 trials.
     >>> sb.trials_per_sample()
     4

--- a/docs/_source/guide/usage.rst
+++ b/docs/_source/guide/usage.rst
@@ -1345,28 +1345,31 @@ reported as the block is built, so it is visible without asking for it.
     >>> tb.trials_per_sample()
     12
 
-The `prioritize` argument names the factors to keep fully crossed. The
-remaining listed factors are demoted: each of their levels must still
-appear at least once, but their combinations with the other factors
-are no longer required. Keeping `colr` and `size` crossed brings the
-same design down to four trials, and the report names what was demoted.
+The `optional` argument names factors that need only each of their own
+levels to appear, in no particular combination. The factors given
+positionally keep the full requirement, so each factor is classified
+once. Making `cue` optional brings the same design down to four trials,
+and the report names what was made optional.
 
   .. doctest::
 
     >>> pb = CrossBlock(design=design, crossing=[task],
-    ...                 constraints=[CoverAllCombinations(colr, size, cue,
-    ...                                                   prioritize=[colr, size])])
-    CoverAllCombinations(colr, size, cue, prioritize=[colr, size]) requires 4 trials. (cue: each level appears at least once)
+    ...                 constraints=[CoverAllCombinations(colr, size,
+    ...                                                   optional=[cue])])
+    CoverAllCombinations(colr, size, optional=[cue]) requires 4 trials. (cue: each level appears at least once)
     >>> pb.trials_per_sample()
     4
 
 All four `colr`-`size` combinations still appear and all three `cue`
 levels still appear, but the twelve three-way combinations no longer
-have to. To choose differently, change the `prioritize` list and build
-the block again.
+have to. To choose differently, move factors between the two groups and
+build the block again.
+
+A factor may not be in both groups, since it cannot both require its
+combinations and give them up.
 
 Listing the same factors in two separate constraints expresses the
-same thing without the `prioritize` argument, since each constraint is
+same thing without the `optional` argument, since each constraint is
 sized on its own and the block takes the larger count.
 
   .. doctest::

--- a/sweetpea/_internal/constraint.py
+++ b/sweetpea/_internal/constraint.py
@@ -1274,75 +1274,58 @@ def _val_name(x):
 
 class CoverAllCombinations(Constraint):
     """Requires that the trials of an experiment collectively include every realizable
-    combination of `factors` at least once, or a weaker requirement where
-    `prioritize` names only some of them.
+    combination of `factors` at least once, plus a weaker requirement for each
+    factor named in `optional`.
 
     Factors left out of a crossing are otherwise assigned freely by the solver; this
     constraint coordinates those free choices so that the union of all trials covers
     every combination. The number of trials needed is computed automatically and the
     block is grown to fit (see the auto-sizing notes on the block constructors).
 
-    The two arguments do different jobs: `factors` sets what the constraint
-    governs, and `prioritize` sets how strongly. A factor named in `prioritize`
-    must appear in combination with the others named there; a factor left out of
-    it needs only each of its own levels to appear somewhere, in no particular
-    combination. Naming none of them---the default---requires every combination
-    of `factors`, and naming a subset trades coverage for a shorter experiment.
+    The two groups carry different guarantees. The positional `factors` must
+    appear in combination with one another---every combination of their levels.
+    A factor named in `optional` needs only each of its own levels to appear
+    somewhere, in no particular combination, which trades coverage for a shorter
+    experiment. A factor may not be in both groups.
 
     Usage::
 
         Nest(outer, inner, [CoverAllCombinations(color, word)])
         CrossBlock(design, crossing, [CoverAllCombinations(color, word)])
-        CrossBlock(design, crossing, [CoverAllCombinations(color, word, cue,
-                                                           prioritize=[color, word])])
+        CrossBlock(design, crossing, [CoverAllCombinations(color, word,
+                                                           optional=[cue])])
     """
 
-    def __init__(self, *factors, prioritize=[]):
+    def __init__(self, *factors, optional=[]):
         who = "CoverAllCombinations"
-        factor_list = list(factors)
-        if factor_list == []:
-            raise ValueError(who, "factor list must be non-empty")
-        argcheck(who, factor_list, make_islistof(Factor), "factors")
-        self.factors = factor_list
+        required = list(factors)
+        argcheck(who, required, make_islistof(Factor), "factors")
         # Checked before list(), so that a non-iterable (e.g. a stray boolean)
         # reports the parameter by name instead of raising from the conversion.
-        argcheck(who, prioritize, make_islistof(Factor), "prioritize")
-        priority = list(prioritize)
-        self._check_priority(priority, who)
-        self.prioritize = priority
-        # Coverage requirements, one fully-crossed combination set per group.
-        # The lone default group is the full cross of `factors`; a priority list
-        # splits it into the kept group plus a singleton per demoted factor.
-        self.groups = (self._grouping_for(priority) if priority
-                       else cast(List[List[Factor]], [factor_list]))
+        argcheck(who, optional, make_islistof(Factor), "optional")
+        self.required = required
+        self.optional = cast(List[Factor], [])
+        for f in optional:
+            if f in required:
+                raise ValueError((who,
+                                  "'{}' is both required and optional; a factor belongs "
+                                  "to one group or the other".format(f.name)))
+            if f not in self.optional:
+                self.optional.append(f)
+        # Every factor the constraint governs, whichever guarantee it carries.
+        self.factors = self.required + self.optional
+        if self.factors == []:
+            raise ValueError(who, "factor list must be non-empty")
+        # Coverage requirements, one fully-crossed combination set per group:
+        # the required factors together, then each optional factor on its own so
+        # that only its individual levels have to appear.
+        self.groups = cast(List[List[Factor]],
+                           ([required] if required else [])
+                           + [[f] for f in self.optional])
         # Set by Nest during construction: the inner block whose crossing determines
         # which listed factors are pinned vs. free. None for other block types, in
         # which case the attached block itself is analyzed.
         self._inner_block = cast(Optional[MultiCrossBlockRepeat], None)
-
-    # ~~~~~~~~~~~~~~ Priority grouping ~~~~~~~~~~~~~~
-
-    def _check_priority(self, priority, who) -> None:
-        for f in priority:
-            if f not in self.factors:
-                raise ValueError((who,
-                                  "'{}' is not one of the factors listed in the constraint "
-                                  "({})".format(f.name,
-                                                ", ".join(g.name for g in self.factors))))
-
-    def _grouping_for(self, priority) -> List[List[Factor]]:
-        """Groups for a priority list: the named factors form one fully-crossed
-        group, and each remaining listed factor becomes a group of its own, so
-        only its individual levels are required to appear.
-
-        An empty priority list demotes everything, which is the cheapest
-        grouping; naming every factor reproduces the default single group."""
-        kept = []  # type: List[Factor]
-        for f in priority:
-            if f not in kept:
-                kept.append(f)
-        demoted = [f for f in self.factors if f not in kept]
-        return ([kept] if kept else []) + [[f] for f in demoted]
 
     # ~~~~~~~~~~~~~~ Coverage analysis (the "K" computation) ~~~~~~~~~~~~~~
 
@@ -1633,15 +1616,11 @@ class CoverAllCombinations(Constraint):
                           "the other constraints ({})".format(cap, ", ".join(conflicting))))
 
     def sizing_message(self, total) -> str:
-        """The line a block reports as it grows itself for coverage.
-
-        Demoted factors come from `prioritize` rather than from group sizes: a
-        single prioritized factor leaves the kept group a singleton too, so
-        group size cannot tell kept from demoted."""
+        """The line a block reports as it grows itself for coverage."""
         msg = "{} requires {} trials.".format(repr(self), total)
-        demoted = [str(f.name) for f in self.factors if f not in self.prioritize]
-        if self.prioritize and demoted:
-            msg += " ({}: each level appears at least once)".format(", ".join(demoted))
+        if self.optional:
+            msg += " ({}: each level appears at least once)".format(
+                ", ".join(str(f.name) for f in self.optional))
         return msg
 
     @staticmethod
@@ -1730,12 +1709,11 @@ class CoverAllCombinations(Constraint):
     def desugar(self, replacements: dict) -> List[Constraint]:
         def replace(fs):
             return [replacements.get(f, [f, f])[1] for f in fs]
-        c = CoverAllCombinations(*replace(self.factors))
-        c.prioritize = replace(self.prioritize)
-        # Groups hold the same Factor objects as `factors`, so they need the
-        # same mapping: otherwise a weighted design keeps pre-desugar factors
-        # here and coverage is computed against factors the block no longer has.
-        c.groups = [replace(g) for g in self.groups]
+        # Rebuilding through the constructor re-derives the groups from the
+        # mapped factors, so no group can keep a pre-desugar factor that the
+        # block no longer has.
+        c = CoverAllCombinations(*replace(self.required),
+                                 optional=replace(self.optional))
         c._inner_block = self._inner_block
         return [c]
 
@@ -1799,8 +1777,8 @@ class CoverAllCombinations(Constraint):
         return True
 
     def __repr__(self):
-        args = [f.name for f in self.factors]
-        if self.prioritize:
-            args.append("prioritize=[{}]".format(
-                ", ".join(f.name for f in self.prioritize)))
+        args = [f.name for f in self.required]
+        if self.optional:
+            args.append("optional=[{}]".format(
+                ", ".join(f.name for f in self.optional)))
         return "CoverAllCombinations({})".format(", ".join(args))

--- a/sweetpea/_internal/constraint.py
+++ b/sweetpea/_internal/constraint.py
@@ -1,7 +1,6 @@
 """This module provides constraints for CNF generation."""
 
 import operator as op
-import warnings
 from abc import abstractmethod
 from copy import deepcopy
 from typing import List, Tuple, Any, Union, cast, Dict, Callable, Optional
@@ -1273,36 +1272,22 @@ def _val_name(x):
     return getattr(x, "name", x)
 
 
-class _NoInput(Exception):
-    """Raised when a prompt cannot be answered because no interactive input is
-    available: pytest, CI, or a piped script."""
-
-
-def _prompt(message: str) -> str:
-    """Read one line of interactive input, or raise `_NoInput`.
-
-    Availability is decided by attempting the read rather than by consulting
-    `sys.stdin.isatty()`, which reports False under Jupyter---a normal place to
-    build a design, and one where prompting does work."""
-    try:
-        return input(message)
-    except (EOFError, OSError):
-        raise _NoInput()
-
-
 class CoverAllCombinations(Constraint):
     """Requires that the trials of an experiment collectively include every realizable
-    combination of `factors` at least once.
+    combination of `factors` at least once, or a weaker requirement where
+    `prioritize` names only some of them.
 
     Factors left out of a crossing are otherwise assigned freely by the solver; this
     constraint coordinates those free choices so that the union of all trials covers
     every combination. The number of trials needed is computed automatically and the
     block is grown to fit (see the auto-sizing notes on the block constructors).
 
-    `prioritize` trades coverage for a shorter experiment. Given a list of the
-    listed factors, those stay fully crossed and each remaining factor is
-    demoted to needing only each of its own levels present. `True` negotiates
-    that choice interactively as the block is built.
+    The two arguments do different jobs: `factors` sets what the constraint
+    governs, and `prioritize` sets how strongly. A factor named in `prioritize`
+    must appear in combination with the others named there; a factor left out of
+    it needs only each of its own levels to appear somewhere, in no particular
+    combination. Naming none of them---the default---requires every combination
+    of `factors`, and naming a subset trades coverage for a shorter experiment.
 
     Usage::
 
@@ -1312,25 +1297,24 @@ class CoverAllCombinations(Constraint):
                                                            prioritize=[color, word])])
     """
 
-    def __init__(self, *factors, prioritize=False):
+    def __init__(self, *factors, prioritize=[]):
         who = "CoverAllCombinations"
         factor_list = list(factors)
         if factor_list == []:
             raise ValueError(who, "factor list must be non-empty")
         argcheck(who, factor_list, make_islistof(Factor), "factors")
         self.factors = factor_list
+        # Checked before list(), so that a non-iterable (e.g. a stray boolean)
+        # reports the parameter by name instead of raising from the conversion.
+        argcheck(who, prioritize, make_islistof(Factor), "prioritize")
+        priority = list(prioritize)
+        self._check_priority(priority, who)
+        self.prioritize = priority
         # Coverage requirements, one fully-crossed combination set per group.
         # The lone default group is the full cross of `factors`; a priority list
         # splits it into the kept group plus a singleton per demoted factor.
-        self.groups = cast(List[List[Factor]], [factor_list])
-        if isinstance(prioritize, (list, tuple)):
-            priority = list(prioritize)
-            argcheck(who, priority, make_islistof(Factor), "prioritize")
-            self._check_priority(priority, who)
-            self.prioritize = cast(Union[bool, List[Factor]], priority)
-            self.groups = self._grouping_for(priority)
-        else:
-            self.prioritize = cast(Union[bool, List[Factor]], bool(prioritize))
+        self.groups = (self._grouping_for(priority) if priority
+                       else cast(List[List[Factor]], [factor_list]))
         # Set by Nest during construction: the inner block whose crossing determines
         # which listed factors are pinned vs. free. None for other block types, in
         # which case the attached block itself is analyzed.
@@ -1648,68 +1632,17 @@ class CoverAllCombinations(Constraint):
                           "no trial count up to {} instances reconciles coverage with "
                           "the other constraints ({})".format(cap, ", ".join(conflicting))))
 
-    # ~~~~~~~~~~~~~~ Interactive priority negotiation ~~~~~~~~~~~~~~
+    def sizing_message(self, total) -> str:
+        """The line a block reports as it grows itself for coverage.
 
-    def negotiate_trials(self, block) -> int:
-        """`autosize_trials`, plus the interactive negotiation that
-        ``prioritize=True`` asks for. Separate so that `autosize_trials` stays a
-        pure computation the negotiation can re-run per candidate grouping."""
-        total = self.autosize_trials(block)
-        if self.prioritize is not True or len(self.factors) < 2:
-            # A single listed factor has nothing to demote.
-            return total
-        names = ", ".join(f.name for f in self.factors)
-        by_name = {f.name: f for f in self.factors}
-        chosen = cast(Optional[List[Factor]], None)
-        try:
-            while True:
-                answer = _prompt("\n{} needs {} trials.\nAccept? [Y/n] ".format(
-                    repr(self), total))
-                if answer.strip().lower() not in ("n", "no"):
-                    break
-                while True:
-                    raw = _prompt("Which factors should stay fully crossed?\n"
-                                  "(comma-separated, from: {})\n> ".format(names))
-                    wanted = [w.strip() for w in raw.split(",") if w.strip()]
-                    unknown = [w for w in wanted if w not in by_name]
-                    if not unknown:
-                        break
-                    print("Not listed in this constraint: {}.".format(", ".join(unknown)))
-                priority = [by_name[w] for w in wanted]
-                candidate = self._grouping_for(priority)
-                saved = self.groups
-                self.groups = candidate
-                try:
-                    total = self.autosize_trials(block)
-                except ValueError as e:
-                    # Reject the candidate rather than aborting the whole block:
-                    # the user can still pick a grouping that reconciles.
-                    self.groups = saved
-                    total = self.autosize_trials(block)
-                    print("That grouping cannot be reconciled: {}".format(e))
-                    continue
-                chosen = priority
-                demoted = [str(g[0].name) for g in candidate
-                           if len(g) == 1 and g[0] not in priority]
-                if demoted:
-                    print("That gives {} trials. ({}: each level appears at least "
-                          "once)".format(total, ", ".join(demoted)))
-                else:
-                    print("That gives {} trials.".format(total))
-        except _NoInput:
-            self.groups = [self.factors]
-            total = self.autosize_trials(block)
-            warnings.warn("CoverAllCombinations: no interactive input available, so the "
-                          "prioritize=True prompt was skipped; using the computed trial "
-                          "count of {}".format(total))
-            return total
-        if chosen is not None:
-            # An interactive design is otherwise unreproducible: re-running the
-            # script re-prompts, and the result depends on what was typed.
-            print("\nTo skip this prompt next time:\n    CoverAllCombinations({}, "
-                  "prioritize=[{}])".format(", ".join(str(f.name) for f in self.factors),
-                                            ", ".join(str(f.name) for f in chosen)))
-        return total
+        Demoted factors come from `prioritize` rather than from group sizes: a
+        single prioritized factor leaves the kept group a singleton too, so
+        group size cannot tell kept from demoted."""
+        msg = "{} requires {} trials.".format(repr(self), total)
+        demoted = [str(f.name) for f in self.factors if f not in self.prioritize]
+        if self.prioritize and demoted:
+            msg += " ({}: each level appears at least once)".format(", ".join(demoted))
+        return msg
 
     @staticmethod
     def _k_lower_bound(R_free, slots, slot_weights=None):
@@ -1798,8 +1731,7 @@ class CoverAllCombinations(Constraint):
         def replace(fs):
             return [replacements.get(f, [f, f])[1] for f in fs]
         c = CoverAllCombinations(*replace(self.factors))
-        c.prioritize = (replace(self.prioritize)
-                        if isinstance(self.prioritize, list) else self.prioritize)
+        c.prioritize = replace(self.prioritize)
         # Groups hold the same Factor objects as `factors`, so they need the
         # same mapping: otherwise a weighted design keeps pre-desugar factors
         # here and coverage is computed against factors the block no longer has.
@@ -1868,9 +1800,7 @@ class CoverAllCombinations(Constraint):
 
     def __repr__(self):
         args = [f.name for f in self.factors]
-        if isinstance(self.prioritize, list):
+        if self.prioritize:
             args.append("prioritize=[{}]".format(
                 ", ".join(f.name for f in self.prioritize)))
-        elif self.prioritize:
-            args.append("prioritize=True")
         return "CoverAllCombinations({})".format(", ".join(args))

--- a/sweetpea/_internal/constraint.py
+++ b/sweetpea/_internal/constraint.py
@@ -1,6 +1,7 @@
 """This module provides constraints for CNF generation."""
 
 import operator as op
+import warnings
 from abc import abstractmethod
 from copy import deepcopy
 from typing import List, Tuple, Any, Union, cast, Dict, Callable, Optional
@@ -1272,6 +1273,23 @@ def _val_name(x):
     return getattr(x, "name", x)
 
 
+class _NoInput(Exception):
+    """Raised when a prompt cannot be answered because no interactive input is
+    available: pytest, CI, or a piped script."""
+
+
+def _prompt(message: str) -> str:
+    """Read one line of interactive input, or raise `_NoInput`.
+
+    Availability is decided by attempting the read rather than by consulting
+    `sys.stdin.isatty()`, which reports False under Jupyter---a normal place to
+    build a design, and one where prompting does work."""
+    try:
+        return input(message)
+    except (EOFError, OSError):
+        raise _NoInput()
+
+
 class CoverAllCombinations(Constraint):
     """Requires that the trials of an experiment collectively include every realizable
     combination of `factors` at least once.
@@ -1281,23 +1299,66 @@ class CoverAllCombinations(Constraint):
     every combination. The number of trials needed is computed automatically and the
     block is grown to fit (see the auto-sizing notes on the block constructors).
 
+    `prioritize` trades coverage for a shorter experiment. Given a list of the
+    listed factors, those stay fully crossed and each remaining factor is
+    demoted to needing only each of its own levels present. `True` negotiates
+    that choice interactively as the block is built.
+
     Usage::
 
         Nest(outer, inner, [CoverAllCombinations(color, word)])
         CrossBlock(design, crossing, [CoverAllCombinations(color, word)])
+        CrossBlock(design, crossing, [CoverAllCombinations(color, word, cue,
+                                                           prioritize=[color, word])])
     """
 
-    def __init__(self, *factors):
+    def __init__(self, *factors, prioritize=False):
         who = "CoverAllCombinations"
         factor_list = list(factors)
         if factor_list == []:
             raise ValueError(who, "factor list must be non-empty")
         argcheck(who, factor_list, make_islistof(Factor), "factors")
         self.factors = factor_list
+        # Coverage requirements, one fully-crossed combination set per group.
+        # The lone default group is the full cross of `factors`; a priority list
+        # splits it into the kept group plus a singleton per demoted factor.
+        self.groups = cast(List[List[Factor]], [factor_list])
+        if isinstance(prioritize, (list, tuple)):
+            priority = list(prioritize)
+            argcheck(who, priority, make_islistof(Factor), "prioritize")
+            self._check_priority(priority, who)
+            self.prioritize = cast(Union[bool, List[Factor]], priority)
+            self.groups = self._grouping_for(priority)
+        else:
+            self.prioritize = cast(Union[bool, List[Factor]], bool(prioritize))
         # Set by Nest during construction: the inner block whose crossing determines
         # which listed factors are pinned vs. free. None for other block types, in
         # which case the attached block itself is analyzed.
         self._inner_block = cast(Optional[MultiCrossBlockRepeat], None)
+
+    # ~~~~~~~~~~~~~~ Priority grouping ~~~~~~~~~~~~~~
+
+    def _check_priority(self, priority, who) -> None:
+        for f in priority:
+            if f not in self.factors:
+                raise ValueError((who,
+                                  "'{}' is not one of the factors listed in the constraint "
+                                  "({})".format(f.name,
+                                                ", ".join(g.name for g in self.factors))))
+
+    def _grouping_for(self, priority) -> List[List[Factor]]:
+        """Groups for a priority list: the named factors form one fully-crossed
+        group, and each remaining listed factor becomes a group of its own, so
+        only its individual levels are required to appear.
+
+        An empty priority list demotes everything, which is the cheapest
+        grouping; naming every factor reproduces the default single group."""
+        kept = []  # type: List[Factor]
+        for f in priority:
+            if f not in kept:
+                kept.append(f)
+        demoted = [f for f in self.factors if f not in kept]
+        return ([kept] if kept else []) + [[f] for f in demoted]
 
     # ~~~~~~~~~~~~~~ Coverage analysis (the "K" computation) ~~~~~~~~~~~~~~
 
@@ -1336,11 +1397,11 @@ class CoverAllCombinations(Constraint):
                         return True
         return False
 
-    def _coverage_analysis(self, block, exclusion_block=None):
-        """Structural analysis over `self.factors` for the given analysis block.
-        When `exclusion_block` is given (e.g. the merged block of a Nest), its
-        exclusions are folded into realizability as well, so that an Exclude at
-        any level simply removes combinations from the required set.
+    def _coverage_analysis(self, block, factors, exclusion_block=None):
+        """Structural analysis over `factors` (one coverage group) for the given
+        analysis block. When `exclusion_block` is given (e.g. the merged block of
+        a Nest), its exclusions are folded into realizability as well, so that an
+        Exclude at any level simply removes combinations from the required set.
 
         Returns ``(R, forced, R_free, slots, combo_levels, slot_weights,
         forced_weights)`` where:
@@ -1358,7 +1419,7 @@ class CoverAllCombinations(Constraint):
         - ``forced_weights``: per forced combo, its occurrences per instance
           (sum of the combination weights of the cells that force it).
         """
-        listed = self.factors
+        listed = factors
         crossing_factors = self._cell_factors(block)
         if not crossing_factors:
             return (set(), set(), set(), [], {}, [], {})
@@ -1410,11 +1471,16 @@ class CoverAllCombinations(Constraint):
         return (R, forced, R_free, slots, combo_levels, slot_weights, forced_weights)
 
     def required_instances(self, block=None):
-        """Minimum number of instances (K) needed to cover ``R_free``."""
+        """Minimum number of instances (K) needed to cover ``R_free``, over the
+        largest of the coverage groups."""
         if block is None:
             block = self._inner_block
-        (_, _, R_free, slots, _, slot_weights, _) = self._coverage_analysis(block)
-        return self._min_instances(R_free, slots, slot_weights)
+        k = 1
+        for group in self.groups:
+            (_, _, R_free, slots, _, slot_weights, _) = \
+                self._coverage_analysis(block, group)
+            k = max(k, self._min_instances(R_free, slots, slot_weights))
+        return k
 
     def _relevant_constraints(self, sizing_block):
         """The sizing block's constraints that are statically reconciled into the
@@ -1505,9 +1571,53 @@ class CoverAllCombinations(Constraint):
         for c in analysis.crossings:
             if c is not cell_crossing and any(f in c for f in self.factors):
                 return 0
-        (R, forced, R_free, slots, _, slot_weights, forced_weights) = \
-            self._coverage_analysis(analysis, exclusion_block=block)
         (pins, caps, seqs) = self._relevant_constraints(block)
+        if analysis is not block:
+            # Nest: one instance = one inner-block pass.
+            instance_len = analysis.trials_per_sample() - analysis.common_preamble_size()
+        else:
+            # crossing_size already folds in the crossing's sustain count.
+            instance_len = block.crossing_size(cell_crossing)
+        if instance_len <= 0:
+            return 0
+        # Sequential enrichment applies to listed factors the cells leave free.
+        cell_factors = self._cell_factors(analysis)
+        seq_free = [ct for ct in seqs if ct.factor not in cell_factors]
+        # Each group is sized on its own and the block takes the largest K: one
+        # trial serves one combination from every group at once, so the groups
+        # do not add up. A priority list only ever produces groups that are
+        # disjoint in the factors the cells leave free, so the per-group counts
+        # are independent and the largest is exact rather than a lower bound.
+        k = 1
+        for group in self.groups:
+            k = max(k, self._instances_for_group(block, analysis, group, instance_len,
+                                                 pins, caps, seq_free, who))
+        total = k * instance_len
+        # Round up to complete passes of every crossing. Iterating settles on a
+        # common multiple; the iteration bound avoids chasing a large LCM when
+        # pass lengths are co-prime. crossing_size already folds in sustain.
+        passes = [block.crossing_size(c) for c in block.crossings]
+        for _ in range(4):
+            rounded = total
+            for p in passes:
+                if p > 0 and rounded % p != 0:
+                    rounded = ((rounded // p) + 1) * p
+            if rounded == total:
+                break
+            total = rounded
+        return total
+
+    def _instances_for_group(self, block, analysis, group, instance_len,
+                             pins, caps, seq_free, who) -> int:
+        """Instances (K) needed for one coverage group, with the statically
+        modeled effects of the block's other constraints folded in.
+
+        The ExactlyK arithmetic here counts one group's requirements. Across
+        several groups it therefore under-counts a level's total demand; the
+        residual is left to the solver, as the in-a-row family and LatinSquare
+        already are."""
+        (R, forced, R_free, slots, _, slot_weights, forced_weights) = \
+            self._coverage_analysis(analysis, group, exclusion_block=block)
         # Definitive check: `required` = the capped level's occurrences at K=1
         # (each free combo at least once + each forced combo at its per-instance
         # weight). Adding instances only increases the forced term, so a cap
@@ -1523,17 +1633,6 @@ class CoverAllCombinations(Constraint):
                                   "with '{} {}' but an ExactlyK constraint allows exactly "
                                   "{}".format(required, fname, lname, ct.k)))
         k_opt = self._min_instances(R_free, slots, slot_weights)
-        if analysis is not block:
-            # Nest: one instance = one inner-block pass.
-            instance_len = analysis.trials_per_sample() - analysis.common_preamble_size()
-        else:
-            # crossing_size already folds in the crossing's sustain count.
-            instance_len = block.crossing_size(cell_crossing)
-        if instance_len <= 0:
-            return 0
-        # Sequential enrichment applies to listed factors the cells leave free.
-        cell_factors = self._cell_factors(analysis)
-        seq_free = [ct for ct in seqs if ct.factor not in cell_factors]
         # Scan ceiling: |R_free| instances provably suffice for the plain model
         # (see _min_instances), so twice that (or twice k_opt) leaves headroom
         # for what constraints consume; exhausting it => irreconcilable.
@@ -1542,26 +1641,74 @@ class CoverAllCombinations(Constraint):
         while k <= cap:
             if self._feasible_at(k, instance_len, R_free, forced, slots, pins, caps,
                                  seq_free, block, slot_weights, forced_weights):
-                break
+                return k
             k += 1
-        else:
-            conflicting = [repr(ct) for ct in (pins + caps + seq_free)]
-            raise ValueError((who,
-                              "no trial count up to {} instances reconciles coverage with "
-                              "the other constraints ({})".format(cap, ", ".join(conflicting))))
-        total = k * instance_len
-        # Round up to complete passes of every crossing. Iterating settles on a
-        # common multiple; the iteration bound avoids chasing a large LCM when
-        # pass lengths are co-prime. crossing_size already folds in sustain.
-        passes = [block.crossing_size(c) for c in block.crossings]
-        for _ in range(4):
-            rounded = total
-            for p in passes:
-                if p > 0 and rounded % p != 0:
-                    rounded = ((rounded // p) + 1) * p
-            if rounded == total:
-                break
-            total = rounded
+        conflicting = [repr(ct) for ct in (pins + caps + seq_free)]
+        raise ValueError((who,
+                          "no trial count up to {} instances reconciles coverage with "
+                          "the other constraints ({})".format(cap, ", ".join(conflicting))))
+
+    # ~~~~~~~~~~~~~~ Interactive priority negotiation ~~~~~~~~~~~~~~
+
+    def negotiate_trials(self, block) -> int:
+        """`autosize_trials`, plus the interactive negotiation that
+        ``prioritize=True`` asks for. Separate so that `autosize_trials` stays a
+        pure computation the negotiation can re-run per candidate grouping."""
+        total = self.autosize_trials(block)
+        if self.prioritize is not True or len(self.factors) < 2:
+            # A single listed factor has nothing to demote.
+            return total
+        names = ", ".join(f.name for f in self.factors)
+        by_name = {f.name: f for f in self.factors}
+        chosen = cast(Optional[List[Factor]], None)
+        try:
+            while True:
+                answer = _prompt("\n{} needs {} trials.\nAccept? [Y/n] ".format(
+                    repr(self), total))
+                if answer.strip().lower() not in ("n", "no"):
+                    break
+                while True:
+                    raw = _prompt("Which factors should stay fully crossed?\n"
+                                  "(comma-separated, from: {})\n> ".format(names))
+                    wanted = [w.strip() for w in raw.split(",") if w.strip()]
+                    unknown = [w for w in wanted if w not in by_name]
+                    if not unknown:
+                        break
+                    print("Not listed in this constraint: {}.".format(", ".join(unknown)))
+                priority = [by_name[w] for w in wanted]
+                candidate = self._grouping_for(priority)
+                saved = self.groups
+                self.groups = candidate
+                try:
+                    total = self.autosize_trials(block)
+                except ValueError as e:
+                    # Reject the candidate rather than aborting the whole block:
+                    # the user can still pick a grouping that reconciles.
+                    self.groups = saved
+                    total = self.autosize_trials(block)
+                    print("That grouping cannot be reconciled: {}".format(e))
+                    continue
+                chosen = priority
+                demoted = [str(g[0].name) for g in candidate
+                           if len(g) == 1 and g[0] not in priority]
+                if demoted:
+                    print("That gives {} trials. ({}: each level appears at least "
+                          "once)".format(total, ", ".join(demoted)))
+                else:
+                    print("That gives {} trials.".format(total))
+        except _NoInput:
+            self.groups = [self.factors]
+            total = self.autosize_trials(block)
+            warnings.warn("CoverAllCombinations: no interactive input available, so the "
+                          "prioritize=True prompt was skipped; using the computed trial "
+                          "count of {}".format(total))
+            return total
+        if chosen is not None:
+            # An interactive design is otherwise unreproducible: re-running the
+            # script re-prompts, and the result depends on what was typed.
+            print("\nTo skip this prompt next time:\n    CoverAllCombinations({}, "
+                  "prioritize=[{}])".format(", ".join(str(f.name) for f in self.factors),
+                                            ", ".join(str(f.name) for f in chosen)))
         return total
 
     @staticmethod
@@ -1648,8 +1795,15 @@ class CoverAllCombinations(Constraint):
         return any(factor.uses_factor(f) for factor in self.factors)
 
     def desugar(self, replacements: dict) -> List[Constraint]:
-        factors = [replacements.get(f, [f, f])[1] for f in self.factors]
-        c = CoverAllCombinations(*factors)
+        def replace(fs):
+            return [replacements.get(f, [f, f])[1] for f in fs]
+        c = CoverAllCombinations(*replace(self.factors))
+        c.prioritize = (replace(self.prioritize)
+                        if isinstance(self.prioritize, list) else self.prioritize)
+        # Groups hold the same Factor objects as `factors`, so they need the
+        # same mapping: otherwise a weighted design keeps pre-desugar factors
+        # here and coverage is computed against factors the block no longer has.
+        c.groups = [replace(g) for g in self.groups]
         c._inner_block = self._inner_block
         return [c]
 
@@ -1665,48 +1819,58 @@ class CoverAllCombinations(Constraint):
             validate_factor(block, f)
 
     def apply(self, block: Block, backend_request: BackendRequest) -> None:
-        (_, _, R_free, _, combo_levels, _, _) = self._coverage_analysis(
-            self._analysis_block(block), exclusion_block=block)
-        if not R_free:
-            return
         preamble = block.common_preamble_size()
         num_trials = block.trials_per_sample()
         trials = list(range(1 + preamble, num_trials + 1))
 
         fresh = backend_request.fresh
         formula_parts = cast(List[FormulaWithIff], [])
-        for combo in R_free:
-            levels = combo_levels[combo]
-            state_vars = []
-            for t in trials:
-                sv = fresh
-                fresh += 1
-                state_vars.append(sv)
-                formula_parts.append(Iff(sv, And(list(block.encode_combination(levels, t)))))
-            # At least one trial must instantiate this combination.
-            formula_parts.append(Or(state_vars))
+        analysis = self._analysis_block(block)
+        for group in self.groups:
+            (_, _, R_free, _, combo_levels, _, _) = self._coverage_analysis(
+                analysis, group, exclusion_block=block)
+            # A group's combinations name only its own factors, so a demoted
+            # singleton asks for its level alone; encode_combination takes the
+            # partial assignment as-is.
+            for combo in R_free:
+                levels = combo_levels[combo]
+                state_vars = []
+                for t in trials:
+                    sv = fresh
+                    fresh += 1
+                    state_vars.append(sv)
+                    formula_parts.append(Iff(sv, And(list(block.encode_combination(levels, t)))))
+                # At least one trial must instantiate this combination.
+                formula_parts.append(Or(state_vars))
+        if not formula_parts:
+            return
 
         (cnf, new_fresh) = block.cnf_fn(And(formula_parts), fresh)
         backend_request.cnfs.append(cnf)
         backend_request.fresh = new_fresh
 
     def potential_sample_conforms(self, sample: dict, block: Block) -> bool:
-        (_, _, R_free, _, _, _, _) = self._coverage_analysis(
-            self._analysis_block(block), exclusion_block=block)
-        if not R_free:
-            return True
         num_trials = block.trials_per_sample()
-        for combo in R_free:
-            need = dict(combo)  # factor_name -> level_name
-            found = False
-            for t in range(num_trials):
-                if all(sample[f][t].name == need[f.name] for f in self.factors):
-                    found = True
-                    break
-            if not found:
-                return False
+        analysis = self._analysis_block(block)
+        for group in self.groups:
+            (_, _, R_free, _, _, _, _) = self._coverage_analysis(
+                analysis, group, exclusion_block=block)
+            for combo in R_free:
+                need = dict(combo)  # factor_name -> level_name
+                found = False
+                for t in range(num_trials):
+                    if all(sample[f][t].name == need[f.name] for f in group):
+                        found = True
+                        break
+                if not found:
+                    return False
         return True
 
     def __repr__(self):
-        return "CoverAllCombinations({})".format(
-            ", ".join([f.name for f in self.factors]))
+        args = [f.name for f in self.factors]
+        if isinstance(self.prioritize, list):
+            args.append("prioritize=[{}]".format(
+                ", ".join(f.name for f in self.prioritize)))
+        elif self.prioritize:
+            args.append("prioritize=True")
+        return "CoverAllCombinations({})".format(", ".join(args))

--- a/sweetpea/_internal/cross_block.py
+++ b/sweetpea/_internal/cross_block.py
@@ -119,7 +119,13 @@ class MultiCrossBlockRepeat(Block):
         # needed for coverage. Must run before trials_per_sample() is first cached.
         for ct in self.constraints:
             if isinstance(ct, CoverAllCombinations):
-                target = ct.negotiate_trials(self)
+                target = ct.autosize_trials(self)
+                if target > 0:
+                    # Report what coverage costs, rather than the block's final
+                    # length: MinimumTrials and sustain rounding can lengthen it
+                    # further, which is not coverage's doing. A zero target means
+                    # coverage was not statically modeled, so there is no count.
+                    print(ct.sizing_message(target))
                 if target > self.min_trials:
                     self.min_trials = target
                     for count in self.crossing_sustain_counts:

--- a/sweetpea/_internal/cross_block.py
+++ b/sweetpea/_internal/cross_block.py
@@ -119,7 +119,7 @@ class MultiCrossBlockRepeat(Block):
         # needed for coverage. Must run before trials_per_sample() is first cached.
         for ct in self.constraints:
             if isinstance(ct, CoverAllCombinations):
-                target = ct.autosize_trials(self)
+                target = ct.negotiate_trials(self)
                 if target > self.min_trials:
                     self.min_trials = target
                     for count in self.crossing_sustain_counts:


### PR DESCRIPTION
This is a follow-up to PR #86. Coverage requires every combination of the listed factors, and since that set is the product of their levels, it can imply more trials than an experimenter wants. 

Factors passed as `optional=` need only each of their own levels to appear, not their combinations:

    CoverAllCombinations(colr, size, cue)             # 12 trials
    CoverAllCombinations(colr, size, optional=[cue])  #  4 trials

Positional arguments must be covered in combination with one another, `optional` ones need only be present. A factor in both groups produces an error.

The trial count coverage requires is now printed as the block is built, in both cases:

    CoverAllCombinations(colr, size, optional=[cue]) requires 4 trials. (cue: each level appears at least once)

