### PR TITLE
CoverAllCombinations Phase 2 and Constraint Weakening.

### DIFF
--- a/acceptance/test_constraint_weakening.py
+++ b/acceptance/test_constraint_weakening.py
@@ -1,0 +1,210 @@
+import pytest
+
+from sweetpea import *
+from sweetpea._internal.block import BlockGeometry
+from sweetpea._internal.constraint import CoverAllCombinations
+
+
+def _stroop(n):
+    """Build a Stroop-style design with n colors/words and a derived congruency
+    factor, crossing [congruency, color] (word left free)."""
+    colors = ['red', 'green', 'blue', 'yellow', 'purple'][:n]
+    color = Factor('color', colors)
+    word = Factor('word', colors)
+    congruency = Factor('congruency', [
+        DerivedLevel('con', WithinTrial(lambda c, w: c == w, [color, word])),
+        DerivedLevel('incon', WithinTrial(lambda c, w: c != w, [color, word])),
+    ])
+    return colors, color, word, congruency
+
+
+def _build(n, make_caps):
+    """A covered Stroop block, plus the caps as constructed, so that a test can
+    read back what a relaxation did to them."""
+    colors, color, word, congruency = _stroop(n)
+    caps = make_caps(color, word)
+    block = CrossBlock([congruency, color, word], [congruency, color],
+                       [CoverAllCombinations(color, word)] + caps)
+    return colors, block, caps
+
+
+def _covers_all(experiment, colors):
+    all_pairs = set((c, w) for c in colors for w in colors)
+    return set(zip(experiment['color'], experiment['word'])) == all_pairs
+
+
+# In 3-color Stroop the red-red cell forces one word-red per instance and two
+# free combos (green-red, blue-red) contain word-red, so a cap's demand at K
+# instances is K + 2. Coverage settles at K=2, hence a demand of 4.
+_DEMAND = 4
+
+
+# ~~~~~~~~~~~~ Relax argument checking ~~~~~~~~~~~~
+
+def test_relax_rejects_unsupported_constraint():
+    _, color, word, _ = _stroop(3)
+    with pytest.raises(ValueError) as info:
+        Relax(Pin(0, (word, 'red')), by=1)
+    assert 'ExactlyK' in str(info.value)
+
+
+@pytest.mark.parametrize('by', [0, -1, True, 1.5, 'one'])
+def test_relax_rejects_bad_budget(by):
+    _, color, word, _ = _stroop(3)
+    with pytest.raises(ValueError):
+        Relax(ExactlyK(3, (word, 'red')), by=by)
+
+
+def test_relax_leaves_its_argument_alone():
+    _, color, word, _ = _stroop(3)
+    original = ExactlyK(3, (word, 'red'))
+    relaxed = Relax(original, by=1)
+    assert relaxed is not original
+    assert original.relaxation is None
+    assert relaxed.relaxation.by == 1
+    assert original.k == relaxed.k == 3
+
+
+def test_relax_keeps_the_designs_factor():
+    # A deep copy would clone the level's factor and leave the constraint
+    # pointing outside the design.
+    _, color, word, _ = _stroop(3)
+    relaxed = Relax(ExactlyK(3, (word, 'red')), by=1)
+    assert relaxed.level.factor is word
+
+
+# ~~~~~~~~~~~~ Repair, both failure sites ~~~~~~~~~~~~
+
+@pytest.mark.parametrize('written,by', [
+    (1, 3),   # below the K=1 floor: unreconcilable at any K without widening
+    (3, 1),   # clears the floor, but every K the scan reaches overshoots it
+])
+def test_relax_widens_cap_to_the_demand(written, by):
+    _, block, caps = _build(3, lambda c, w: [Relax(ExactlyK(written, (w, 'red')), by=by)])
+    relaxation = caps[0].relaxation
+    assert relaxation.original_k == written
+    assert relaxation.applied_k == _DEMAND
+    assert caps[0].k == _DEMAND
+    assert block.trials_per_sample() == 12
+
+
+@pytest.mark.parametrize('written,by', [(1, 1), (1, 2)])
+def test_relax_over_budget_errors(written, by):
+    with pytest.raises(ValueError) as info:
+        _build(3, lambda c, w: [Relax(ExactlyK(written, (w, 'red')), by=by)])
+    message = str(info.value)
+    assert str(_DEMAND) in message
+    assert 'Relax' in message
+
+
+def test_cap_within_reach_is_left_alone():
+    _, block, caps = _build(3, lambda c, w: [Relax(ExactlyK(4, (w, 'red')), by=1)])
+    assert caps[0].relaxation.applied_k is None
+    assert caps[0].k == 4
+    assert block.applied_relaxations == []
+
+
+def test_unwrapped_cap_still_errors():
+    with pytest.raises(ValueError):
+        _build(3, lambda c, w: [ExactlyK(1, (w, 'red'))])
+
+
+def test_unwrapped_cap_that_fits_is_unaffected():
+    _, block, _ = _build(3, lambda c, w: [ExactlyK(4, (w, 'red'))])
+    assert block.trials_per_sample() == 12
+    assert block.applied_relaxations == []
+
+
+# ~~~~~~~~~~~~ Sustain scaling ~~~~~~~~~~~~
+
+def test_budget_scales_with_sustained_k():
+    # A budget counts the same occurrences k does, so sustaining the block has
+    # to multiply both or a stated tolerance silently changes size.
+    _, color, word, _ = _stroop(3)
+    relaxed = Relax(ExactlyK(2, (word, 'red')), by=1)
+    relaxed.init_within_block(BlockGeometry(4, 0, {}))
+    relaxed.sustain_within_block(3)
+    assert relaxed.k == 6
+    assert relaxed.relaxation.by == 3
+
+
+# ~~~~~~~~~~~~ Reporting ~~~~~~~~~~~~
+
+def test_relaxation_is_reported_at_construction(capsys):
+    _, block, _ = _build(3, lambda c, w: [Relax(ExactlyK(3, (w, 'red')), by=1)])
+    out = capsys.readouterr().out
+    assert "relaxed from 3 to {}".format(_DEMAND) in out
+    assert 'word red' in out
+    assert block.applied_relaxations
+
+
+def test_relaxation_is_restated_with_the_results(capsys):
+    colors, block, _ = _build(3, lambda c, w: [Relax(ExactlyK(3, (w, 'red')), by=1)])
+    experiments = synthesize_trials(block, 1, sampling_strategy=IterateGen)
+    capsys.readouterr()
+    print_experiments(block, experiments)
+    assert "relaxed from 3 to {}".format(_DEMAND) in capsys.readouterr().out
+
+
+# ~~~~~~~~~~~~ End to end ~~~~~~~~~~~~
+
+def test_relaxed_design_synthesizes():
+    colors, block, caps = _build(3, lambda c, w: [Relax(ExactlyK(3, (w, 'red')), by=1)])
+    experiments = synthesize_trials(block, 2, sampling_strategy=IterateGen)
+    assert experiments
+    for e in experiments:
+        assert _covers_all(e, colors)
+        assert e['word'].count('red') == caps[0].relaxation.applied_k
+
+
+# ~~~~~~~~~~~~ Composition ~~~~~~~~~~~~
+
+def _simple(constraints):
+    color = Factor('color', ['red', 'green', 'blue'])
+    word = Factor('word', ['red', 'green', 'blue'])
+    return color, word, CrossBlock([color, word], [color],
+                                   [CoverAllCombinations(color, word)]
+                                   + constraints(color, word))
+
+
+def test_relax_on_a_whole_factor_reaches_every_level():
+    # A cap named on a factor desugars into one per level, and the copies carry
+    # the authorization; the constraint the caller holds stays as written.
+    cap = []
+
+    def make(color, word):
+        cap.append(Relax(ExactlyK(2, word), by=1))
+        return cap
+
+    color, word, block = _simple(make)
+    assert len(block.applied_relaxations) == 3
+    for level in ('red', 'green', 'blue'):
+        assert any("word {}".format(level) in m for m in block.applied_relaxations)
+    assert cap[0].k == 2
+    assert cap[0].relaxation.applied_k is None
+
+
+def test_relax_alongside_several_coverage_constraints():
+    cap = []
+
+    def make(color, word):
+        cap.append(Relax(ExactlyK(2, (word, 'red')), by=2))
+        return cap
+
+    color, word, block = _simple(make)
+    assert cap[0].relaxation.applied_k == 3
+    assert block.trials_per_sample() == 9
+
+
+def test_rebuilding_measures_the_budget_from_the_written_value():
+    # The repair mutates the constraint, so a second build has to keep
+    # measuring from what the user wrote rather than drifting upward.
+    color = Factor('color', ['red', 'green', 'blue'])
+    word = Factor('word', ['red', 'green', 'blue'])
+    cap = Relax(ExactlyK(2, (word, 'red')), by=1)
+    for _ in range(2):
+        CrossBlock([color, word], [color],
+                   [CoverAllCombinations(color, word), cap])
+        assert cap.relaxation.original_k == 2
+        assert cap.relaxation.applied_k == 3
+        assert cap.k == 3

--- a/acceptance/test_cover_all_combinations.py
+++ b/acceptance/test_cover_all_combinations.py
@@ -304,6 +304,12 @@ def _trio():
     return colr, size, cue, task
 
 
+def _coverage_of(block):
+    """The desugared constraint the block sizes itself from."""
+    return next(c for c in block.constraints
+                if isinstance(c, CoverAllCombinations))
+
+
 def _trio_block(colr, size, cue, task, required=None, **kw):
     """All three factors required by default, which is full coverage."""
     required = [colr, size, cue] if required is None else required
@@ -317,10 +323,20 @@ def test_no_optional_keeps_full_coverage(kw):
     assert _trio_block(colr, size, cue, task, **kw).trials_per_sample() == 12
 
 
-def test_optional_reduces_trials():
+def test_optional_is_covered_until_it_is_given_up():
+    # Naming cue optional does not give it up; coverage still asks for every
+    # colr-size-cue combination, which is the full 12 trials.
+    colr, size, cue, task = _trio()
+    block = _trio_block(colr, size, cue, task, required=[colr, size], optional=[cue])
+    assert block.trials_per_sample() == 12
+
+
+def test_giving_up_an_optional_factor_shortens_the_block():
     # colr x size needs 2 passes and cue's 3 levels need 2, so K = 2.
     colr, size, cue, task = _trio()
     block = _trio_block(colr, size, cue, task, required=[colr, size], optional=[cue])
+    _coverage_of(block).drop_one()
+    block.resize_for_coverage()
     assert block.trials_per_sample() == 4
 
 
@@ -328,14 +344,24 @@ def test_optional_ignores_duplicates():
     colr, size, cue, task = _trio()
     block = _trio_block(colr, size, cue, task, required=[colr, size],
                         optional=[cue, cue])
+    coverage = _coverage_of(block)
+    assert coverage.optional == [cue]
+    # One factor listed once, so one drop exhausts what can be given up.
+    coverage.drop_one()
+    assert not coverage.can_drop()
+    block.resize_for_coverage()
     assert block.trials_per_sample() == 4
 
 
 def test_optional_crossed_factor_is_harmless():
-    # `task` is crossed, so its group is satisfied by every pass.
+    # `task` is crossed, so once given up its group is satisfied by every pass.
     colr, size, cue, task = _trio()
     block = _trio_block(colr, size, cue, task, required=[colr, size],
                         optional=[task, cue])
+    coverage = _coverage_of(block)
+    while coverage.can_drop():
+        coverage.drop_one()
+    block.resize_for_coverage()
     assert block.trials_per_sample() == 4
 
 
@@ -408,9 +434,13 @@ def test_optional_in_nest():
     # own 8 word-cue combinations, so K = 8 over passes of 6.
     full = Nest(outer, inner, [CoverAllCombinations(color, word, cue)])
     assert full.trials_per_sample() == 48
-    # Making cue optional leaves the 6 free color-word pairs over 3 slots: K = 2.
+    # Naming cue optional changes nothing until it is given up.
     fewer = Nest(outer, inner,
                  [CoverAllCombinations(color, word, optional=[cue])])
+    assert fewer.trials_per_sample() == 48
+    # Given up, the 6 free color-word pairs over 3 slots leave K = 2.
+    _coverage_of(fewer).drop_one()
+    fewer.resize_for_coverage()
     assert fewer.trials_per_sample() == 12
 
 
@@ -439,19 +469,63 @@ def test_reports_the_count_under_full_coverage(capsys):
     assert 'each level appears' not in out
 
 
-def test_reports_the_count_and_optional_factors(capsys):
+def test_reports_the_full_count_before_anything_is_given_up(capsys):
     colr, size, cue, task = _trio()
     _trio_block(colr, size, cue, task, required=[colr, size], optional=[cue])
     out = capsys.readouterr().out
-    assert ('CoverAllCombinations(colr, size, optional=[cue]) requires 4 trials. '
-            '(cue: each level appears at least once)') in out
+    assert 'CoverAllCombinations(colr, size, optional=[cue]) requires 12 trials.' in out
+    # Nothing has been given up yet, so nothing is named as given up.
+    assert 'each level appears' not in out
 
 
-def test_reports_every_optional_factor(capsys):
+def test_reports_factors_once_they_are_given_up(capsys):
     colr, size, cue, task = _trio()
-    _trio_block(colr, size, cue, task, required=[colr], optional=[size, cue])
+    block = _trio_block(colr, size, cue, task, required=[colr], optional=[size, cue])
+    coverage = _coverage_of(block)
+    while coverage.can_drop():
+        coverage.drop_one()
+    capsys.readouterr()
+    block.resize_for_coverage()
+    assert '(size, cue: each level appears at least once)' in capsys.readouterr().out
+
+
+# ~~~~~~~~~~~~ The hint about what else could be given up ~~~~~~~~~~~~
+
+def test_hint_names_the_required_factors(capsys):
+    colr, size, cue, task = _trio()
+    _trio_block(colr, size, cue, task)
+    assert 'Any of colr, size, cue can be moved to `optional`' in capsys.readouterr().out
+
+
+def test_hint_names_only_what_is_still_required(capsys):
+    colr, size, cue, task = _trio()
+    _trio_block(colr, size, cue, task, required=[colr, size], optional=[cue])
     out = capsys.readouterr().out
-    assert '(size, cue: each level appears at least once)' in out
+    assert 'Any of colr, size can be moved to `optional`' in out
+
+
+def test_no_hint_when_nothing_is_left_to_move(capsys):
+    colr, size, cue, task = _trio()
+    _trio_block(colr, size, cue, task, required=[], optional=[cue])
+    assert 'can be moved to `optional`' not in capsys.readouterr().out
+
+
+def test_no_hint_for_a_single_factor(capsys):
+    # Giving up the only factor leaves coverage asking almost nothing, so it is
+    # not worth suggesting.
+    colr, size, cue, task = _trio()
+    CrossBlock(design=[task, colr], crossing=[task],
+               constraints=[CoverAllCombinations(colr)])
+    assert 'can be moved to `optional`' not in capsys.readouterr().out
+
+
+def test_hint_is_not_repeated_after_a_drop(capsys):
+    colr, size, cue, task = _trio()
+    block = _trio_block(colr, size, cue, task, required=[colr, size], optional=[cue])
+    _coverage_of(block).drop_one()
+    capsys.readouterr()
+    block.resize_for_coverage()
+    assert 'can be moved to `optional`' not in capsys.readouterr().out
 
 
 def test_reports_each_constraint_separately(capsys):

--- a/acceptance/test_cover_all_combinations.py
+++ b/acceptance/test_cover_all_combinations.py
@@ -291,7 +291,7 @@ def test_unmodeled_conflict_yields_hint(capsys):
     assert 'AtLeastKInARow' in out
 
 
-# ~~~~~~~~~~~~ Coverage/trials tradeoff (prioritize) ~~~~~~~~~~~~
+# ~~~~~~~~~~~~ Coverage/trials tradeoff (required vs optional) ~~~~~~~~~~~~
 
 def _trio():
     """`task` is crossed while colr, size, and cue ride free, so covering all
@@ -304,48 +304,52 @@ def _trio():
     return colr, size, cue, task
 
 
-def _trio_block(colr, size, cue, task, listed=None, **kw):
-    listed = listed if listed is not None else [colr, size, cue]
+def _trio_block(colr, size, cue, task, required=None, **kw):
+    """All three factors required by default, which is full coverage."""
+    required = [colr, size, cue] if required is None else required
     return CrossBlock(design=[task, colr, size, cue], crossing=[task],
-                      constraints=[CoverAllCombinations(*listed, **kw)])
+                      constraints=[CoverAllCombinations(*required, **kw)])
 
 
-@pytest.mark.parametrize('kw', [{}, {'prioritize': []}])
-def test_prioritize_empty_keeps_full_coverage(kw):
+@pytest.mark.parametrize('kw', [{}, {'optional': []}])
+def test_no_optional_keeps_full_coverage(kw):
     colr, size, cue, task = _trio()
     assert _trio_block(colr, size, cue, task, **kw).trials_per_sample() == 12
 
 
-def test_prioritize_reduces_trials():
+def test_optional_reduces_trials():
     # colr x size needs 2 passes and cue's 3 levels need 2, so K = 2.
     colr, size, cue, task = _trio()
-    block = _trio_block(colr, size, cue, task, prioritize=[colr, size])
+    block = _trio_block(colr, size, cue, task, required=[colr, size], optional=[cue])
     assert block.trials_per_sample() == 4
 
 
-def test_prioritize_every_factor_is_full_coverage():
+def test_optional_ignores_duplicates():
     colr, size, cue, task = _trio()
-    block = _trio_block(colr, size, cue, task, prioritize=[colr, size, cue])
-    assert block.trials_per_sample() == 12
-
-
-def test_prioritize_ignores_duplicates():
-    colr, size, cue, task = _trio()
-    block = _trio_block(colr, size, cue, task, prioritize=[colr, colr, size])
+    block = _trio_block(colr, size, cue, task, required=[colr, size],
+                        optional=[cue, cue])
     assert block.trials_per_sample() == 4
 
 
-def test_prioritize_demoting_crossed_factor_is_harmless():
-    # `task` is crossed, so its singleton group is satisfied by every pass.
+def test_optional_crossed_factor_is_harmless():
+    # `task` is crossed, so its group is satisfied by every pass.
     colr, size, cue, task = _trio()
-    block = _trio_block(colr, size, cue, task, listed=[task, colr, size, cue],
-                        prioritize=[colr, size])
+    block = _trio_block(colr, size, cue, task, required=[colr, size],
+                        optional=[task, cue])
     assert block.trials_per_sample() == 4
 
 
-def test_prioritize_keeps_both_guarantees():
+def test_optional_without_any_required_factors():
+    # Nothing has to be covered in combination; each cue level just has to
+    # appear, which two passes can hold.
     colr, size, cue, task = _trio()
-    block = _trio_block(colr, size, cue, task, prioritize=[colr, size])
+    block = _trio_block(colr, size, cue, task, required=[], optional=[cue])
+    assert block.trials_per_sample() == 4
+
+
+def test_optional_keeps_both_guarantees():
+    colr, size, cue, task = _trio()
+    block = _trio_block(colr, size, cue, task, required=[colr, size], optional=[cue])
     exps = synthesize_trials(block, 1, sampling_strategy=IterateGen)
     assert exps
     for e in exps:
@@ -355,7 +359,7 @@ def test_prioritize_keeps_both_guarantees():
 
 
 def test_two_coverage_constraints_take_the_larger():
-    # Two constraints express the same thing as prioritize=[colr, size].
+    # Two constraints express the same thing as optional=[cue].
     colr, size, cue, task = _trio()
     block = CrossBlock(design=[task, colr, size, cue], crossing=[task],
                        constraints=[CoverAllCombinations(colr, size),
@@ -369,27 +373,32 @@ def test_two_coverage_constraints_take_the_larger():
         assert set(e['cue']) == {'c1', 'c2', 'c3'}
 
 
-def test_prioritize_unknown_factor_raises():
+def test_factor_cannot_be_required_and_optional():
     colr, size, cue, task = _trio()
+    with pytest.raises(ValueError, match='both required and optional'):
+        CoverAllCombinations(colr, size, optional=[size])
+
+
+def test_no_factors_at_all_raises():
     with pytest.raises(ValueError):
-        CoverAllCombinations(colr, size, prioritize=[cue])
+        CoverAllCombinations()
 
 
-def test_prioritize_rejects_a_bool():
+def test_optional_rejects_a_bool():
     colr, size, cue, task = _trio()
-    with pytest.raises(ValueError, match='prioritize'):
-        CoverAllCombinations(colr, size, cue, prioritize=True)
+    with pytest.raises(ValueError, match='optional'):
+        CoverAllCombinations(colr, size, cue, optional=True)
 
 
-def test_prioritize_repr_shows_the_choice():
+def test_repr_shows_the_groups():
     colr, size, cue, task = _trio()
-    assert repr(CoverAllCombinations(colr, size, cue, prioritize=[colr, size])) == \
-        'CoverAllCombinations(colr, size, cue, prioritize=[colr, size])'
-    assert repr(CoverAllCombinations(colr, size, cue)) == \
-        'CoverAllCombinations(colr, size, cue)'
+    assert (repr(CoverAllCombinations(colr, size, optional=[cue]))
+            == 'CoverAllCombinations(colr, size, optional=[cue])')
+    assert (repr(CoverAllCombinations(colr, size, cue))
+            == 'CoverAllCombinations(colr, size, cue)')
 
 
-def test_prioritize_in_nest():
+def test_optional_in_nest():
     colors, color, word, congruency, _ = _stroop(3)
     cue = Factor('cue', ['c1', 'c2', 'c3', 'c4'])
     inner = CrossBlock([congruency, color, word, cue], [congruency, color], [])
@@ -399,20 +408,19 @@ def test_prioritize_in_nest():
     # own 8 word-cue combinations, so K = 8 over passes of 6.
     full = Nest(outer, inner, [CoverAllCombinations(color, word, cue)])
     assert full.trials_per_sample() == 48
-    # Demoting cue leaves the 6 free color-word pairs over 3 slots: K = 2.
+    # Making cue optional leaves the 6 free color-word pairs over 3 slots: K = 2.
     fewer = Nest(outer, inner,
-                 [CoverAllCombinations(color, word, cue, prioritize=[color, word])])
+                 [CoverAllCombinations(color, word, optional=[cue])])
     assert fewer.trials_per_sample() == 12
 
 
-def test_prioritize_with_weighted_crossing():
+def test_optional_with_weighted_crossing():
     # Weighted levels on the crossed factor still size correctly once some of
-    # the listed factors are demoted.
+    # the governed factors are optional.
     colors, color, word, congruency = _stroop_weighted(4, 2)
     cue = Factor('cue', ['c1', 'c2', 'c3'])
     block = CrossBlock([congruency, color, word, cue], [congruency, color],
-                       [CoverAllCombinations(color, word, cue,
-                                             prioritize=[color, word])])
+                       [CoverAllCombinations(color, word, optional=[cue])])
     exps = synthesize_trials(block, 1, sampling_strategy=IterateGen)
     assert exps
     for e in exps:
@@ -427,23 +435,21 @@ def test_reports_the_count_under_full_coverage(capsys):
     _trio_block(colr, size, cue, task)
     out = capsys.readouterr().out
     assert 'CoverAllCombinations(colr, size, cue) requires 12 trials.' in out
-    # Nothing was demoted, so nothing is said about individual levels.
+    # Nothing is optional, so nothing is said about individual levels.
     assert 'each level appears' not in out
 
 
-def test_reports_the_count_and_demotions_under_prioritize(capsys):
+def test_reports_the_count_and_optional_factors(capsys):
     colr, size, cue, task = _trio()
-    _trio_block(colr, size, cue, task, prioritize=[colr, size])
+    _trio_block(colr, size, cue, task, required=[colr, size], optional=[cue])
     out = capsys.readouterr().out
-    assert ('CoverAllCombinations(colr, size, cue, prioritize=[colr, size]) '
-            'requires 4 trials. (cue: each level appears at least once)') in out
+    assert ('CoverAllCombinations(colr, size, optional=[cue]) requires 4 trials. '
+            '(cue: each level appears at least once)') in out
 
 
-def test_reports_demotions_for_a_single_prioritized_factor(capsys):
-    # Every group is a singleton here, so group size cannot tell the kept
-    # factor from the demoted ones; the report comes from `prioritize`.
+def test_reports_every_optional_factor(capsys):
     colr, size, cue, task = _trio()
-    _trio_block(colr, size, cue, task, prioritize=[colr])
+    _trio_block(colr, size, cue, task, required=[colr], optional=[size, cue])
     out = capsys.readouterr().out
     assert '(size, cue: each level appears at least once)' in out
 

--- a/acceptance/test_cover_all_combinations.py
+++ b/acceptance/test_cover_all_combinations.py
@@ -222,7 +222,7 @@ def test_k_lower_bound_tight_for_stroop(n, expected_k):
     # matching scan does a single confirming check.
     _, color, word, _, inner = _stroop(n)
     cac = CoverAllCombinations(color, word)
-    (_, _, R_free, slots, _, sw, _) = cac._coverage_analysis(inner)
+    (_, _, R_free, slots, _, sw, _) = cac._coverage_analysis(inner, [color, word])
     assert cac._k_lower_bound(R_free, slots, sw) == expected_k
     assert cac.required_instances(inner) == expected_k
 
@@ -289,6 +289,201 @@ def test_unmodeled_conflict_yields_hint(capsys):
     out = capsys.readouterr().out
     assert 'CoverAllCombinations' in out
     assert 'AtLeastKInARow' in out
+
+
+# ~~~~~~~~~~~~ Coverage/trials tradeoff (prioritize) ~~~~~~~~~~~~
+
+def _trio():
+    """`task` is crossed while colr, size, and cue ride free, so covering all
+    three together is what drives the trial count: 2*2*3 = 12 combinations over
+    2 free slots per pass, hence 12 trials."""
+    colr = Factor('colr', ['red', 'green'])
+    size = Factor('size', ['big', 'small'])
+    cue = Factor('cue', ['c1', 'c2', 'c3'])
+    task = Factor('task', ['A', 'B'])
+    return colr, size, cue, task
+
+
+def _trio_block(colr, size, cue, task, listed=None, **kw):
+    listed = listed if listed is not None else [colr, size, cue]
+    return CrossBlock(design=[task, colr, size, cue], crossing=[task],
+                      constraints=[CoverAllCombinations(*listed, **kw)])
+
+
+class _Answers:
+    """Stands in for `input`, replaying scripted answers and recording the
+    prompts it was asked."""
+
+    def __init__(self, *answers):
+        self.answers = list(answers)
+        self.prompts = []
+
+    def __call__(self, prompt=''):
+        self.prompts.append(prompt)
+        if not self.answers:
+            raise AssertionError('unexpected extra prompt: {}'.format(prompt))
+        return self.answers.pop(0)
+
+
+@pytest.mark.parametrize('kw', [{}, {'prioritize': False}])
+def test_prioritize_off_keeps_full_coverage(kw):
+    colr, size, cue, task = _trio()
+    assert _trio_block(colr, size, cue, task, **kw).trials_per_sample() == 12
+
+
+def test_prioritize_reduces_trials():
+    # colr x size needs 2 passes and cue's 3 levels need 2, so K = 2.
+    colr, size, cue, task = _trio()
+    block = _trio_block(colr, size, cue, task, prioritize=[colr, size])
+    assert block.trials_per_sample() == 4
+
+
+def test_prioritize_every_factor_is_full_coverage():
+    colr, size, cue, task = _trio()
+    block = _trio_block(colr, size, cue, task, prioritize=[colr, size, cue])
+    assert block.trials_per_sample() == 12
+
+
+def test_prioritize_empty_demotes_everything():
+    colr, size, cue, task = _trio()
+    block = _trio_block(colr, size, cue, task, prioritize=[])
+    assert block.trials_per_sample() == 4
+
+
+def test_prioritize_ignores_duplicates():
+    colr, size, cue, task = _trio()
+    block = _trio_block(colr, size, cue, task, prioritize=[colr, colr, size])
+    assert block.trials_per_sample() == 4
+
+
+def test_prioritize_demoting_crossed_factor_is_harmless():
+    # `task` is crossed, so its singleton group is satisfied by every pass.
+    colr, size, cue, task = _trio()
+    block = _trio_block(colr, size, cue, task, listed=[task, colr, size, cue],
+                        prioritize=[colr, size])
+    assert block.trials_per_sample() == 4
+
+
+def test_prioritize_keeps_both_guarantees():
+    colr, size, cue, task = _trio()
+    block = _trio_block(colr, size, cue, task, prioritize=[colr, size])
+    exps = synthesize_trials(block, 1, sampling_strategy=IterateGen)
+    assert exps
+    for e in exps:
+        assert set(zip(e['colr'], e['size'])) == set(
+            (c, s) for c in ['red', 'green'] for s in ['big', 'small'])
+        assert set(e['cue']) == {'c1', 'c2', 'c3'}
+
+
+def test_two_coverage_constraints_take_the_larger():
+    # Two constraints express the same thing as prioritize=[colr, size].
+    colr, size, cue, task = _trio()
+    block = CrossBlock(design=[task, colr, size, cue], crossing=[task],
+                       constraints=[CoverAllCombinations(colr, size),
+                                    CoverAllCombinations(cue)])
+    assert block.trials_per_sample() == 4
+    exps = synthesize_trials(block, 1, sampling_strategy=IterateGen)
+    assert exps
+    for e in exps:
+        assert set(zip(e['colr'], e['size'])) == set(
+            (c, s) for c in ['red', 'green'] for s in ['big', 'small'])
+        assert set(e['cue']) == {'c1', 'c2', 'c3'}
+
+
+def test_prioritize_unknown_factor_raises():
+    colr, size, cue, task = _trio()
+    with pytest.raises(ValueError):
+        CoverAllCombinations(colr, size, prioritize=[cue])
+
+
+def test_prioritize_repr_shows_the_choice():
+    colr, size, cue, task = _trio()
+    assert repr(CoverAllCombinations(colr, size, cue, prioritize=[colr, size])) == \
+        'CoverAllCombinations(colr, size, cue, prioritize=[colr, size])'
+    assert repr(CoverAllCombinations(colr, size, cue, prioritize=True)) == \
+        'CoverAllCombinations(colr, size, cue, prioritize=True)'
+
+
+def test_prioritize_in_nest():
+    colors, color, word, congruency, _ = _stroop(3)
+    cue = Factor('cue', ['c1', 'c2', 'c3', 'c4'])
+    inner = CrossBlock([congruency, color, word, cue], [congruency, color], [])
+    instance = Factor('instance', ['a', 'b'])
+    outer = CrossBlock([instance], [instance], [])
+    # Full coverage: each incongruent cell is the only one that can serve its
+    # own 8 word-cue combinations, so K = 8 over passes of 6.
+    full = Nest(outer, inner, [CoverAllCombinations(color, word, cue)])
+    assert full.trials_per_sample() == 48
+    # Demoting cue leaves the 6 free color-word pairs over 3 slots: K = 2.
+    fewer = Nest(outer, inner,
+                 [CoverAllCombinations(color, word, cue, prioritize=[color, word])])
+    assert fewer.trials_per_sample() == 12
+
+
+def test_prioritize_with_weighted_crossing():
+    # Weighted levels on the crossed factor still size correctly once some of
+    # the listed factors are demoted.
+    colors, color, word, congruency = _stroop_weighted(4, 2)
+    cue = Factor('cue', ['c1', 'c2', 'c3'])
+    block = CrossBlock([congruency, color, word, cue], [congruency, color],
+                       [CoverAllCombinations(color, word, cue,
+                                             prioritize=[color, word])])
+    exps = synthesize_trials(block, 1, sampling_strategy=IterateGen)
+    assert exps
+    for e in exps:
+        assert _covers_all(e, colors)
+        assert set(e['cue']) == {'c1', 'c2', 'c3'}
+
+
+# ~~~~~~~~~~~~ Interactive negotiation ~~~~~~~~~~~~
+
+def test_interactive_accepting_the_offer_changes_nothing(monkeypatch):
+    colr, size, cue, task = _trio()
+    answers = _Answers('y')
+    monkeypatch.setattr('builtins.input', answers)
+    block = _trio_block(colr, size, cue, task, prioritize=True)
+    assert block.trials_per_sample() == 12
+    assert '12 trials' in answers.prompts[0]
+
+
+def test_interactive_declining_then_choosing(monkeypatch, capsys):
+    colr, size, cue, task = _trio()
+    monkeypatch.setattr('builtins.input', _Answers('n', 'colr, size', 'y'))
+    block = _trio_block(colr, size, cue, task, prioritize=True)
+    assert block.trials_per_sample() == 4
+    out = capsys.readouterr().out
+    assert 'That gives 4 trials' in out
+    assert 'cue' in out
+    # The session has to be reproducible without the prompt.
+    assert 'prioritize=[colr, size]' in out
+
+
+def test_interactive_reprompts_on_unknown_factor(monkeypatch, capsys):
+    colr, size, cue, task = _trio()
+    monkeypatch.setattr('builtins.input', _Answers('n', 'task', 'colr, size', 'y'))
+    block = _trio_block(colr, size, cue, task, prioritize=True)
+    assert block.trials_per_sample() == 4
+    assert 'Not listed in this constraint: task' in capsys.readouterr().out
+
+
+def test_interactive_single_factor_skips_the_prompt(monkeypatch):
+    # Nothing to demote, so the user is never asked.
+    colr, size, cue, task = _trio()
+    monkeypatch.setattr('builtins.input', _Answers())
+    block = _trio_block(colr, size, cue, task, listed=[cue], prioritize=True)
+    assert block.trials_per_sample() == 4
+
+
+def test_prioritize_without_interactive_input_warns(monkeypatch):
+    colr, size, cue, task = _trio()
+
+    def _no_input(prompt=''):
+        raise OSError('reading from stdin while output is captured')
+
+    monkeypatch.setattr('builtins.input', _no_input)
+    with pytest.warns(UserWarning, match='no interactive input'):
+        block = _trio_block(colr, size, cue, task, prioritize=True)
+    assert block.trials_per_sample() == 12
 
 
 # ~~~~~~~~~~~~ Validation errors ~~~~~~~~~~~~

--- a/acceptance/test_cover_all_combinations.py
+++ b/acceptance/test_cover_all_combinations.py
@@ -310,23 +310,8 @@ def _trio_block(colr, size, cue, task, listed=None, **kw):
                       constraints=[CoverAllCombinations(*listed, **kw)])
 
 
-class _Answers:
-    """Stands in for `input`, replaying scripted answers and recording the
-    prompts it was asked."""
-
-    def __init__(self, *answers):
-        self.answers = list(answers)
-        self.prompts = []
-
-    def __call__(self, prompt=''):
-        self.prompts.append(prompt)
-        if not self.answers:
-            raise AssertionError('unexpected extra prompt: {}'.format(prompt))
-        return self.answers.pop(0)
-
-
-@pytest.mark.parametrize('kw', [{}, {'prioritize': False}])
-def test_prioritize_off_keeps_full_coverage(kw):
+@pytest.mark.parametrize('kw', [{}, {'prioritize': []}])
+def test_prioritize_empty_keeps_full_coverage(kw):
     colr, size, cue, task = _trio()
     assert _trio_block(colr, size, cue, task, **kw).trials_per_sample() == 12
 
@@ -342,12 +327,6 @@ def test_prioritize_every_factor_is_full_coverage():
     colr, size, cue, task = _trio()
     block = _trio_block(colr, size, cue, task, prioritize=[colr, size, cue])
     assert block.trials_per_sample() == 12
-
-
-def test_prioritize_empty_demotes_everything():
-    colr, size, cue, task = _trio()
-    block = _trio_block(colr, size, cue, task, prioritize=[])
-    assert block.trials_per_sample() == 4
 
 
 def test_prioritize_ignores_duplicates():
@@ -396,12 +375,18 @@ def test_prioritize_unknown_factor_raises():
         CoverAllCombinations(colr, size, prioritize=[cue])
 
 
+def test_prioritize_rejects_a_bool():
+    colr, size, cue, task = _trio()
+    with pytest.raises(ValueError, match='prioritize'):
+        CoverAllCombinations(colr, size, cue, prioritize=True)
+
+
 def test_prioritize_repr_shows_the_choice():
     colr, size, cue, task = _trio()
     assert repr(CoverAllCombinations(colr, size, cue, prioritize=[colr, size])) == \
         'CoverAllCombinations(colr, size, cue, prioritize=[colr, size])'
-    assert repr(CoverAllCombinations(colr, size, cue, prioritize=True)) == \
-        'CoverAllCombinations(colr, size, cue, prioritize=True)'
+    assert repr(CoverAllCombinations(colr, size, cue)) == \
+        'CoverAllCombinations(colr, size, cue)'
 
 
 def test_prioritize_in_nest():
@@ -435,55 +420,42 @@ def test_prioritize_with_weighted_crossing():
         assert set(e['cue']) == {'c1', 'c2', 'c3'}
 
 
-# ~~~~~~~~~~~~ Interactive negotiation ~~~~~~~~~~~~
+# ~~~~~~~~~~~~ Reporting the trial count ~~~~~~~~~~~~
 
-def test_interactive_accepting_the_offer_changes_nothing(monkeypatch):
+def test_reports_the_count_under_full_coverage(capsys):
     colr, size, cue, task = _trio()
-    answers = _Answers('y')
-    monkeypatch.setattr('builtins.input', answers)
-    block = _trio_block(colr, size, cue, task, prioritize=True)
-    assert block.trials_per_sample() == 12
-    assert '12 trials' in answers.prompts[0]
-
-
-def test_interactive_declining_then_choosing(monkeypatch, capsys):
-    colr, size, cue, task = _trio()
-    monkeypatch.setattr('builtins.input', _Answers('n', 'colr, size', 'y'))
-    block = _trio_block(colr, size, cue, task, prioritize=True)
-    assert block.trials_per_sample() == 4
+    _trio_block(colr, size, cue, task)
     out = capsys.readouterr().out
-    assert 'That gives 4 trials' in out
-    assert 'cue' in out
-    # The session has to be reproducible without the prompt.
-    assert 'prioritize=[colr, size]' in out
+    assert 'CoverAllCombinations(colr, size, cue) requires 12 trials.' in out
+    # Nothing was demoted, so nothing is said about individual levels.
+    assert 'each level appears' not in out
 
 
-def test_interactive_reprompts_on_unknown_factor(monkeypatch, capsys):
+def test_reports_the_count_and_demotions_under_prioritize(capsys):
     colr, size, cue, task = _trio()
-    monkeypatch.setattr('builtins.input', _Answers('n', 'task', 'colr, size', 'y'))
-    block = _trio_block(colr, size, cue, task, prioritize=True)
-    assert block.trials_per_sample() == 4
-    assert 'Not listed in this constraint: task' in capsys.readouterr().out
+    _trio_block(colr, size, cue, task, prioritize=[colr, size])
+    out = capsys.readouterr().out
+    assert ('CoverAllCombinations(colr, size, cue, prioritize=[colr, size]) '
+            'requires 4 trials. (cue: each level appears at least once)') in out
 
 
-def test_interactive_single_factor_skips_the_prompt(monkeypatch):
-    # Nothing to demote, so the user is never asked.
+def test_reports_demotions_for_a_single_prioritized_factor(capsys):
+    # Every group is a singleton here, so group size cannot tell the kept
+    # factor from the demoted ones; the report comes from `prioritize`.
     colr, size, cue, task = _trio()
-    monkeypatch.setattr('builtins.input', _Answers())
-    block = _trio_block(colr, size, cue, task, listed=[cue], prioritize=True)
-    assert block.trials_per_sample() == 4
+    _trio_block(colr, size, cue, task, prioritize=[colr])
+    out = capsys.readouterr().out
+    assert '(size, cue: each level appears at least once)' in out
 
 
-def test_prioritize_without_interactive_input_warns(monkeypatch):
+def test_reports_each_constraint_separately(capsys):
     colr, size, cue, task = _trio()
-
-    def _no_input(prompt=''):
-        raise OSError('reading from stdin while output is captured')
-
-    monkeypatch.setattr('builtins.input', _no_input)
-    with pytest.warns(UserWarning, match='no interactive input'):
-        block = _trio_block(colr, size, cue, task, prioritize=True)
-    assert block.trials_per_sample() == 12
+    CrossBlock(design=[task, colr, size, cue], crossing=[task],
+               constraints=[CoverAllCombinations(colr, size),
+                            CoverAllCombinations(cue)])
+    out = capsys.readouterr().out
+    assert 'CoverAllCombinations(colr, size) requires' in out
+    assert 'CoverAllCombinations(cue) requires' in out
 
 
 # ~~~~~~~~~~~~ Validation errors ~~~~~~~~~~~~

--- a/acceptance/test_unsat_fallback.py
+++ b/acceptance/test_unsat_fallback.py
@@ -98,12 +98,14 @@ def test_unwrapped_constraint_is_not_weakened(build, make):
     assert synthesize_trials(block, 1, sampling_strategy=IterateGen) == []
 
 
-def test_budget_too_small_restores_the_written_value(capsys):
+def test_budget_too_small_applies_nothing(capsys):
+    # Steps taken during the search are kept, so that a later concession starts
+    # from them, but nothing counts as applied without a design to show for it.
     block, (cap,) = _covered(
         lambda c, w: [Relax(AtLeastKInARow(7, (w, 'red')), by=1)])
     assert synthesize_trials(block, 1, sampling_strategy=IterateGen) == []
-    assert cap.k == 7
-    assert cap.relaxation.applied_k is None
+    assert cap.k == 6
+    assert block.applied_relaxations == []
     assert 'was not enough' in capsys.readouterr().out
 
 
@@ -160,3 +162,86 @@ def test_weakening_is_reported_with_the_results(capsys):
     capsys.readouterr()
     print_experiments(block, experiments)
     assert 'relaxed from 1 to 2' in capsys.readouterr().out
+
+
+# ~~~~~~~~~~~~ Giving up optional coverage factors ~~~~~~~~~~~~
+
+def _weighted(constraints, optional):
+    """`color` is 3:1 weighted and crossed, so red is three quarters of every
+    pass. Full coverage of word x cue is 12 combinations, so 3 passes of 4 = 12
+    trials holding 9 reds, which AtMostKInARow(2) cannot arrange since
+    9 > 2 * (12 - 9 + 1). Giving cue up leaves 4 combinations, one pass, 3 reds,
+    which it can."""
+    color = Factor('color', [Level('red', 3), 'green'])
+    word = Factor('word', ['w1', 'w2', 'w3', 'w4'])
+    cue = Factor('cue', ['c1', 'c2', 'c3'])
+    made = constraints(color)
+    block = CrossBlock([color, word, cue], [color],
+                       [CoverAllCombinations(word, optional=optional(word, cue))]
+                       + made)
+    return color, word, cue, block, made
+
+
+def test_optional_factor_is_given_up_and_the_block_shrinks():
+    color, word, cue, block, _ = _weighted(
+        lambda c: [AtMostKInARow(2, (c, 'red'))], lambda w, q: [q])
+    assert block.trials_per_sample() == 12
+    experiments = synthesize_trials(block, 1, sampling_strategy=IterateGen)
+    assert experiments
+    assert block.trials_per_sample() == 4
+    assert set(experiments[0]['word']) == {'w1', 'w2', 'w3', 'w4'}
+
+
+def test_giving_up_is_reported_with_the_results(capsys):
+    _, _, _, block, _ = _weighted(
+        lambda c: [AtMostKInARow(2, (c, 'red'))], lambda w, q: [q])
+    experiments = synthesize_trials(block, 1, sampling_strategy=IterateGen)
+    assert any('gave up cue' in m for m in block.applied_relaxations)
+    capsys.readouterr()
+    print_experiments(block, experiments)
+    assert 'gave up cue' in capsys.readouterr().out
+
+
+def test_last_optional_factor_is_given_up_first():
+    colr = Factor('colr', ['red', 'green'])
+    size = Factor('size', ['big', 'small'])
+    cue = Factor('cue', ['c1', 'c2'])
+    coverage = CoverAllCombinations(colr, optional=[size, cue])
+    assert coverage.drop_one() is cue
+    assert coverage.drop_one() is size
+    assert not coverage.can_drop()
+
+
+def test_relax_and_giving_up_apply_in_order():
+    # AtMostKInARow(1) needs k >= 3 at twelve trials, so one Relax step is not
+    # enough on its own; giving cue up as well brings the block within reach.
+    cap = []
+
+    def make(color):
+        cap.append(Relax(AtMostKInARow(1, (color, 'red')), by=1))
+        return cap
+
+    _, _, _, block, _ = _weighted(make, lambda w, q: [q])
+    experiments = synthesize_trials(block, 1, sampling_strategy=IterateGen)
+    assert experiments
+    assert cap[0].relaxation.applied_k == 2
+    assert block.trials_per_sample() == 4
+    reported = ' '.join(block.applied_relaxations)
+    assert 'AtMostKInARow' in reported
+    assert 'gave up cue' in reported
+
+
+def test_nothing_left_to_give_up_returns_no_sequences():
+    # AtLeastKInARow(5) cannot be met at either size, and there is only one
+    # factor to give up.
+    colors = ['red', 'green', 'blue']
+    color = Factor('color', colors)
+    word = Factor('word', colors)
+    congruency = Factor('congruency', [
+        DerivedLevel('con', WithinTrial(lambda c, w: c == w, [color, word])),
+        DerivedLevel('incon', WithinTrial(lambda c, w: c != w, [color, word])),
+    ])
+    block = CrossBlock([congruency, color, word], [congruency, color],
+                       [CoverAllCombinations(color, optional=[word]),
+                        AtLeastKInARow(5, (word, 'red'))])
+    assert synthesize_trials(block, 1, sampling_strategy=IterateGen) == []

--- a/acceptance/test_unsat_fallback.py
+++ b/acceptance/test_unsat_fallback.py
@@ -1,0 +1,162 @@
+import pytest
+
+from sweetpea import *
+from sweetpea._internal.constraint import CoverAllCombinations, relax_budget
+from sweetpea._internal.core import SolveOutcome
+from importlib import import_module
+
+# The generate package rebinds this name to the function it re-exports,
+# so the module itself has to be fetched by path.
+sample_module = import_module('sweetpea._internal.core.generate.sample_non_uniform')
+from sweetpea._internal.main import _weaken_until_satisfiable
+from sweetpea._internal.sampling_strategy.base import SamplingResult
+
+
+def _stroop():
+    colors = ['red', 'green', 'blue']
+    color = Factor('color', colors)
+    word = Factor('word', colors)
+    congruency = Factor('congruency', [
+        DerivedLevel('con', WithinTrial(lambda c, w: c == w, [color, word])),
+        DerivedLevel('incon', WithinTrial(lambda c, w: c != w, [color, word])),
+    ])
+    return color, word, congruency
+
+
+def _covered(constraints):
+    """Stroop with coverage, where AtLeastKInARow(7) has no solution: coverage
+    fixes the block at 12 trials holding four word-reds, which cannot form a run
+    of seven."""
+    color, word, congruency = _stroop()
+    made = constraints(color, word)
+    block = CrossBlock([congruency, color, word], [congruency, color],
+                       [CoverAllCombinations(color, word)] + made)
+    return block, made
+
+
+def _crowded(constraints):
+    """Four trials of which three are red. No arrangement keeps the reds apart
+    at k=1, since 3 > 1 * (4 - 3 + 1); k=2 admits one."""
+    color = Factor('color', [Level('red', 3), 'green'])
+    made = constraints(color)
+    return CrossBlock([color], [color], made), made
+
+
+# ~~~~~~~~~~~~ Outcome plumbing ~~~~~~~~~~~~
+
+def test_no_solution_on_first_solve_is_unsatisfiable(monkeypatch, tmp_path):
+    monkeypatch.setattr(sample_module, 'cryptominisat_solve', lambda f, d=False: [])
+    (solutions, outcome) = sample_module.compute_solutions(tmp_path / 'p.cnf', 3, 2)
+    assert solutions == []
+    assert outcome is SolveOutcome.UNSATISFIABLE
+
+
+def test_no_solution_after_one_is_satisfied(monkeypatch, tmp_path):
+    answers = [[1, 2, 3], []]
+    monkeypatch.setattr(sample_module, 'cryptominisat_solve',
+                        lambda f, d=False: answers.pop(0))
+    monkeypatch.setattr(sample_module, 'update_file', lambda f, s: None)
+    (solutions, outcome) = sample_module.compute_solutions(tmp_path / 'p.cnf', 3, 5)
+    assert len(solutions) == 1
+    assert outcome is SolveOutcome.SATISFIED
+
+
+def test_solver_failure_is_unknown(monkeypatch, tmp_path):
+    monkeypatch.setattr(sample_module, 'cryptominisat_solve', lambda f, d=False: None)
+    (solutions, outcome) = sample_module.compute_solutions(tmp_path / 'p.cnf', 3, 2)
+    assert solutions == []
+    assert outcome is SolveOutcome.UNKNOWN
+
+
+# ~~~~~~~~~~~~ Weakening after UNSAT ~~~~~~~~~~~~
+
+def test_at_least_k_in_a_row_weakens_downward():
+    block, (cap,) = _covered(
+        lambda c, w: [Relax(AtLeastKInARow(7, (w, 'red')), by=6)])
+    experiments = synthesize_trials(block, 1, sampling_strategy=IterateGen)
+    assert experiments
+    assert cap.relaxation.original_k == 7
+    assert cap.relaxation.applied_k == cap.k < 7
+
+
+def test_at_most_k_in_a_row_weakens_upward():
+    block, (cap,) = _crowded(
+        lambda c: [Relax(AtMostKInARow(1, (c, 'red')), by=1)])
+    experiments = synthesize_trials(block, 1, sampling_strategy=IterateGen)
+    assert experiments
+    assert cap.relaxation.original_k == 1
+    assert cap.relaxation.applied_k == 2
+    assert block.applied_relaxations
+
+
+@pytest.mark.parametrize('build,make', [
+    (_covered, lambda c, w: [AtLeastKInARow(7, (w, 'red'))]),
+    (_crowded, lambda c: [AtMostKInARow(1, (c, 'red'))]),
+])
+def test_unwrapped_constraint_is_not_weakened(build, make):
+    block, _ = build(make)
+    assert synthesize_trials(block, 1, sampling_strategy=IterateGen) == []
+
+
+def test_budget_too_small_restores_the_written_value(capsys):
+    block, (cap,) = _covered(
+        lambda c, w: [Relax(AtLeastKInARow(7, (w, 'red')), by=1)])
+    assert synthesize_trials(block, 1, sampling_strategy=IterateGen) == []
+    assert cap.k == 7
+    assert cap.relaxation.applied_k is None
+    assert 'was not enough' in capsys.readouterr().out
+
+
+def test_unknown_outcome_does_not_weaken():
+    # A solver failure says nothing about the design, so nothing is altered and
+    # no re-solve is attempted.
+    block, (cap,) = _crowded(lambda c: [Relax(AtMostKInARow(1, (c, 'red')), by=2)])
+    result = SamplingResult([], {}, SolveOutcome.UNKNOWN)
+
+    def run():
+        raise AssertionError('must not re-solve on an unknown outcome')
+
+    assert _weaken_until_satisfiable(block, result, run) is result
+    assert cap.k == 1
+    assert cap.relaxation.applied_k is None
+
+
+def test_at_least_k_of_one_has_no_room_to_weaken():
+    color = Factor('color', ['red', 'green'])
+    assert relax_budget(Relax(AtLeastKInARow(1, (color, 'red')), by=3)) == 0
+
+
+# ~~~~~~~~~~~~ One relaxable constraint per experiment ~~~~~~~~~~~~
+
+def test_two_relaxed_constraints_are_rejected():
+    color, word, congruency = _stroop()
+    with pytest.raises(ValueError) as info:
+        CrossBlock([congruency, color, word], [congruency, color],
+                   [Relax(AtMostKInARow(2, (word, 'red')), by=1),
+                    Relax(AtLeastKInARow(2, (color, 'red')), by=1)])
+    assert 'one constraint' in str(info.value)
+
+
+def test_relax_accepts_the_in_a_row_pair():
+    color, word, _ = _stroop()
+    for constraint in (AtMostKInARow(2, (word, 'red')),
+                       AtLeastKInARow(2, (word, 'red')),
+                       ExactlyK(2, (word, 'red'))):
+        assert Relax(constraint, by=1).relaxation.by == 1
+
+
+def test_relax_still_rejects_other_constraints():
+    color, _, _ = _stroop()
+    with pytest.raises(ValueError) as info:
+        Relax(MinimumTrials(10), by=1)
+    assert 'AtMostKInARow' in str(info.value)
+
+
+# ~~~~~~~~~~~~ Reporting ~~~~~~~~~~~~
+
+def test_weakening_is_reported_with_the_results(capsys):
+    block, _ = _crowded(lambda c: [Relax(AtMostKInARow(1, (c, 'red')), by=1)])
+    experiments = synthesize_trials(block, 1, sampling_strategy=IterateGen)
+    capsys.readouterr()
+    print_experiments(block, experiments)
+    assert 'relaxed from 1 to 2' in capsys.readouterr().out

--- a/docs/_source/api/constraints.rst
+++ b/docs/_source/api/constraints.rst
@@ -177,12 +177,11 @@ Constraints
 
               Constrains an experiment so that its trials collectively
               include every realizable combination of the levels of
-              `factors` at least once, plus a weaker requirement for
-              each factor named in `optional`. A factor that is left
-              out of a crossing is otherwise assigned freely by the
-              solver, so nothing normally guarantees that a particular
-              combination ever appears; this constraint coordinates
-              those free choices.
+              `factors` and of `optional` at least once. A factor that
+              is left out of a crossing is otherwise assigned freely by
+              the solver, so nothing normally guarantees that a
+              particular combination ever appears; this constraint
+              coordinates those free choices.
 
               Unlike most constraints, :class:`CoverAllCombinations`
               can increase the number of trials: the count needed for
@@ -207,17 +206,20 @@ Constraints
               weighted levels elsewhere in the crossing are supported,
               and they change the trial count accordingly.
 
-              The two groups carry different guarantees. The
-              positional `factors` must appear in combination with one
-              another---every combination of their levels. A factor
-              named in `optional` needs only each of its own levels to
-              appear somewhere, in no particular combination. Since the
-              required set is the product of the levels involved,
-              moving a factor to `optional` trades coverage for a
-              shorter experiment. A factor may not be in both groups.
+              The two groups differ in what may be given up, not in
+              what is required to begin with. Every listed factor must
+              appear in combination with the others. When the solver
+              reports that the design has no solution, the factors named
+              in `optional` are given up one at a time, the last one
+              first: a factor that has been given up needs only each of
+              its own levels to appear, in no particular combination,
+              and the block is re-sized to the shorter experiment that
+              leaves. A factor may not be in both groups.
 
-              The number of trials required is printed as the block is
-              built, along with any factors that were made optional.
+              Because factors are given up while the design is being
+              solved, the trial count is provisional until then. The
+              count is printed as the block is built and again whenever
+              it changes, naming the factors given up so far.
 
               See :ref:`Covering All Combinations <covering-all-combinations>`
               for more information.
@@ -226,6 +228,8 @@ Constraints
                               combination with one another
               :type factors: Factor
               :param optional: further factors the constraint governs,
+                               which may be given up---last one first---
+                               when the design has no solution, leaving
                                each needing only its own levels to
                                appear rather than its combinations
               :type optional: List[Factor]

--- a/docs/_source/api/constraints.rst
+++ b/docs/_source/api/constraints.rst
@@ -142,13 +142,13 @@ Constraints
               :type factors: List[Factor]
               :rtype: Constraint
 
-.. class:: sweetpea.CoverAllCombinations(*factors, prioritize=[])
+.. class:: sweetpea.CoverAllCombinations(*factors, optional=[])
 
               Constrains an experiment so that its trials collectively
               include every realizable combination of the levels of
-              `factors` at least once, or a weaker requirement where
-              `prioritize` names only some of them. A factor that is
-              left out of a crossing is otherwise assigned freely by the
+              `factors` at least once, plus a weaker requirement for
+              each factor named in `optional`. A factor that is left
+              out of a crossing is otherwise assigned freely by the
               solver, so nothing normally guarantees that a particular
               combination ever appears; this constraint coordinates
               those free choices.
@@ -176,32 +176,28 @@ Constraints
               weighted levels elsewhere in the crossing are supported,
               and they change the trial count accordingly.
 
-              The two arguments do different jobs: `factors` sets what
-              the constraint governs, and `prioritize` sets how
-              strongly. A factor named in `prioritize` must appear in
-              combination with the others named there; a factor left out
-              of it needs only each of its own levels to appear
-              somewhere, in no particular combination. Naming none of
-              them---the default---requires every combination of
-              `factors`. Since the required set is the product of the
-              levels involved, naming a subset trades coverage for a
-              shorter experiment.
+              The two groups carry different guarantees. The
+              positional `factors` must appear in combination with one
+              another---every combination of their levels. A factor
+              named in `optional` needs only each of its own levels to
+              appear somewhere, in no particular combination. Since the
+              required set is the product of the levels involved,
+              moving a factor to `optional` trades coverage for a
+              shorter experiment. A factor may not be in both groups.
 
               The number of trials required is printed as the block is
-              built, along with any factors that were demoted.
+              built, along with any factors that were made optional.
 
               See :ref:`Covering All Combinations <covering-all-combinations>`
               for more information.
 
-              :param factors: the factors this constraint governs; any
-                              factor not listed here is unaffected by it
+              :param factors: the factors that must appear in
+                              combination with one another
               :type factors: Factor
-              :param prioritize: which of `factors` must appear in
-                                 combination with one another; those left
-                                 out need only each of their own levels to
-                                 appear. Empty requires every combination
-                                 of `factors`.
-              :type prioritize: List[Factor]
+              :param optional: further factors the constraint governs,
+                               each needing only its own levels to
+                               appear rather than its combinations
+              :type optional: List[Factor]
               :rtype: Constraint
 
 .. class:: sweetpea.ContinuousConstraint(factors, predicate)

--- a/docs/_source/api/constraints.rst
+++ b/docs/_source/api/constraints.rst
@@ -105,6 +105,37 @@ Constraints
               :type level: Union[Level, Tuple[Factor, Any], Tuple[Factor, Level], Factor]
               :rtype: Constraint
 
+.. function:: sweetpea.Relax(constraint, by)
+
+              Authorizes `constraint` to be weakened by up to `by`,
+              when it would otherwise leave the experiment with no
+              satisfying trial sequences. Returns a copy of
+              `constraint` to use in place of the original; the
+              constraint passed in is unchanged.
+
+              A constraint is weakened only when it is passed through
+              this function, and any adjustment that is applied is
+              reported as the experiment runs and again by
+              :func:`.print_experiments`. An experiment may relax one
+              constraint.
+
+              :class:`.ExactlyK`, :class:`.AtMostKInARow` and
+              :class:`.AtLeastKInARow` can be relaxed; passing any
+              other constraint raises an error. An :class:`.ExactlyK`
+              is adjusted while the block is sized, where
+              :class:`.CoverAllCombinations` can compute the value it
+              must take. The in-a-row constraints have no such model,
+              so they are adjusted only after the solver reports that
+              the design has no solution. See
+              :ref:`relaxing-a-constraint`.
+
+              :param constraint: the constraint that may be weakened
+              :type constraint: Constraint
+              :param by: how many steps the constraint's `k` may move
+                         towards the weaker requirement
+              :type by: int
+              :rtype: Constraint
+
 .. class:: sweetpea.Sequential(factor)
 
               Constrains the experiment so that the levels of `factor`

--- a/docs/_source/api/constraints.rst
+++ b/docs/_source/api/constraints.rst
@@ -142,7 +142,7 @@ Constraints
               :type factors: List[Factor]
               :rtype: Constraint
 
-.. class:: sweetpea.CoverAllCombinations(*factors)
+.. class:: sweetpea.CoverAllCombinations(*factors, prioritize=False)
 
               Constrains an experiment so that its trials collectively
               include every realizable combination of the levels of
@@ -175,11 +175,25 @@ Constraints
               weighted levels elsewhere in the crossing are supported,
               and they change the trial count accordingly.
 
+              Since the combinations to cover are the product of the
+              listed factors' levels, `prioritize` trades coverage for
+              a shorter experiment. Given a list of the listed factors,
+              those stay fully crossed, while each remaining factor is
+              demoted to needing only each of its own levels present.
+              Passing ``True`` instead reports the trial count as the
+              block is built and asks which factors to keep; where no
+              interactive input is available, that prompt is skipped
+              with a warning and the full count is used.
+
               See :ref:`Covering All Combinations <covering-all-combinations>`
               for more information.
 
               :param factors: the factors whose level combinations must all appear
               :type factors: Factor
+              :param prioritize: the factors to keep fully crossed, or a
+                                 boolean selecting full coverage or an
+                                 interactive choice
+              :type prioritize: Union[bool, List[Factor]]
               :rtype: Constraint
 
 .. class:: sweetpea.ContinuousConstraint(factors, predicate)

--- a/docs/_source/api/constraints.rst
+++ b/docs/_source/api/constraints.rst
@@ -178,10 +178,11 @@ Constraints
               Constrains an experiment so that its trials collectively
               include every realizable combination of the levels of
               `factors` and of `optional` at least once. A factor that
-              is left out of a crossing is otherwise assigned freely by
-              the solver, so nothing normally guarantees that a
-              particular combination ever appears; this constraint
-              coordinates those free choices.
+              is left out of a crossing is assigned by the solver
+              subject only to whatever other constraints apply, so
+              nothing otherwise guarantees that a particular
+              combination ever appears; this constraint supplies that
+              guarantee.
 
               Unlike most constraints, :class:`CoverAllCombinations`
               can increase the number of trials: the count needed for

--- a/docs/_source/api/constraints.rst
+++ b/docs/_source/api/constraints.rst
@@ -142,15 +142,16 @@ Constraints
               :type factors: List[Factor]
               :rtype: Constraint
 
-.. class:: sweetpea.CoverAllCombinations(*factors, prioritize=False)
+.. class:: sweetpea.CoverAllCombinations(*factors, prioritize=[])
 
               Constrains an experiment so that its trials collectively
               include every realizable combination of the levels of
-              `factors` at least once. A factor that is left out of a
-              crossing is otherwise assigned freely by the solver, so
-              nothing normally guarantees that a particular combination
-              ever appears; this constraint coordinates those free
-              choices.
+              `factors` at least once, or a weaker requirement where
+              `prioritize` names only some of them. A factor that is
+              left out of a crossing is otherwise assigned freely by the
+              solver, so nothing normally guarantees that a particular
+              combination ever appears; this constraint coordinates
+              those free choices.
 
               Unlike most constraints, :class:`CoverAllCombinations`
               can increase the number of trials: the count needed for
@@ -175,25 +176,32 @@ Constraints
               weighted levels elsewhere in the crossing are supported,
               and they change the trial count accordingly.
 
-              Since the combinations to cover are the product of the
-              listed factors' levels, `prioritize` trades coverage for
-              a shorter experiment. Given a list of the listed factors,
-              those stay fully crossed, while each remaining factor is
-              demoted to needing only each of its own levels present.
-              Passing ``True`` instead reports the trial count as the
-              block is built and asks which factors to keep; where no
-              interactive input is available, that prompt is skipped
-              with a warning and the full count is used.
+              The two arguments do different jobs: `factors` sets what
+              the constraint governs, and `prioritize` sets how
+              strongly. A factor named in `prioritize` must appear in
+              combination with the others named there; a factor left out
+              of it needs only each of its own levels to appear
+              somewhere, in no particular combination. Naming none of
+              them---the default---requires every combination of
+              `factors`. Since the required set is the product of the
+              levels involved, naming a subset trades coverage for a
+              shorter experiment.
+
+              The number of trials required is printed as the block is
+              built, along with any factors that were demoted.
 
               See :ref:`Covering All Combinations <covering-all-combinations>`
               for more information.
 
-              :param factors: the factors whose level combinations must all appear
+              :param factors: the factors this constraint governs; any
+                              factor not listed here is unaffected by it
               :type factors: Factor
-              :param prioritize: the factors to keep fully crossed, or a
-                                 boolean selecting full coverage or an
-                                 interactive choice
-              :type prioritize: Union[bool, List[Factor]]
+              :param prioritize: which of `factors` must appear in
+                                 combination with one another; those left
+                                 out need only each of their own levels to
+                                 appear. Empty requires every combination
+                                 of `factors`.
+              :type prioritize: List[Factor]
               :rtype: Constraint
 
 .. class:: sweetpea.ContinuousConstraint(factors, predicate)

--- a/docs/_source/guide/usage.rst
+++ b/docs/_source/guide/usage.rst
@@ -1381,3 +1381,84 @@ sized on its own and the block takes the larger count.
     CoverAllCombinations(cue) requires 4 trials.
     >>> sb.trials_per_sample()
     4
+
+
+.. _relaxing-a-constraint:
+
+Relaxing a Constraint
+---------------------
+
+A constraint can conflict with what :class:`.CoverAllCombinations`
+requires. Crossing `color` alone over three colors gives nine trials
+that hold each `color`-`word` combination once, so `word` is `red` in
+three of them. An :class:`.ExactlyK` constraint allowing two such
+trials contradicts that, and the block reports the conflict and stops.
+
+:func:`.Relax` authorizes a constraint to be weakened instead. It takes
+the constraint and a budget, and returns a copy to use in its place.
+Coverage sizing then computes the value the constraint has to take and
+adjusts it, provided the change stays within the budget.
+
+  .. doctest::
+
+    >>> from sweetpea import Factor, CrossBlock, CoverAllCombinations, ExactlyK, Relax
+    >>> color = Factor("color", ["red", "green", "blue"])
+    >>> word  = Factor("word",  ["red", "green", "blue"])
+    >>> cap = Relax(ExactlyK(2, (word, "red")), by=1)
+    >>> rb = CrossBlock(design=[color, word], crossing=[color],
+    ...                 constraints=[CoverAllCombinations(color, word), cap])
+    ExactlyK for 'word red' relaxed from 2 to 3, as CoverAllCombinations(color, word) requires.
+    CoverAllCombinations(color, word) requires 9 trials.
+    >>> rb.trials_per_sample()
+    9
+
+The value that was applied is also available on the constraint, for a
+script that needs to record what the experiment actually required.
+
+  .. doctest::
+
+    >>> cap.relaxation.original_k, cap.relaxation.applied_k
+    (2, 3)
+
+`by` is a budget, not a target. The constraint's `k` may end up
+anywhere within `by` of the value written, and the adjustment applied
+is the smallest one that resolves the conflict. A constraint that is
+already consistent with coverage is left alone, whether or not it was
+relaxed. When the required value lies outside the budget, the block
+reports the value it would need and stops rather than exceeding what
+was authorized.
+
+Weakening is never inferred. A constraint that was not passed through
+:func:`.Relax` keeps its stated value, and a conflict involving it
+remains an error. Every adjustment that is applied is printed as the
+block is built and repeated by :func:`.print_experiments`, so it
+appears alongside the trial sequences it produced.
+
+Weakening After the Solver
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+:class:`.AtMostKInARow` and :class:`.AtLeastKInARow` can also be
+relaxed. They govern the order of trials rather than a count, so
+coverage sizing cannot work out the value they must take, and no
+adjustment is made until the solver reports that the design has no
+solution. SweetPea then moves `k` one step at a time towards the weaker
+requirement---a larger `k` for :class:`.AtMostKInARow`, a smaller one
+for :class:`.AtLeastKInARow`---re-solving after each step and stopping
+at the first value that works.
+
+::
+
+    block = CrossBlock(design=[color, word], crossing=[color],
+                       constraints=[Relax(AtMostKInARow(1, (color, "red")), by=2)])
+
+`k` never falls below one, so an :class:`.AtLeastKInARow` already at
+one has no room to move. If the budget runs out before a solution is
+found, the constraint is restored to the value written and no trial
+sequences are returned.
+
+An experiment may relax one constraint. Weakening is only attempted
+when the solver reports the design unsatisfiable; a solver that fails
+to answer says nothing about the design, so nothing is adjusted.
+
+Constraints other than these three cannot be relaxed, and passing one
+to :func:`.Relax` raises an error.

--- a/docs/_source/guide/usage.rst
+++ b/docs/_source/guide/usage.rst
@@ -1130,6 +1130,7 @@ cannot hold four combinations, so the block grows to four trials.
     >>> cb = CrossBlock(design=[task, colr, size], crossing=[task],
     ...                 constraints=[CoverAllCombinations(colr, size)])
     CoverAllCombinations(colr, size) requires 4 trials.
+    Any of colr, size can be moved to `optional`, to be given up for a shorter experiment if no solution is found.
     >>> cb.trials_per_sample()
     4
 
@@ -1166,6 +1167,7 @@ passes---nine trials---are required.
     >>> b = CrossBlock(design=[color, word], crossing=[color],
     ...                constraints=[CoverAllCombinations(color, word)])
     CoverAllCombinations(color, word) requires 9 trials.
+    Any of color, word can be moved to `optional`, to be given up for a shorter experiment if no solution is found.
     >>> b.trials_per_sample()
     9
 
@@ -1198,6 +1200,7 @@ ruling out one `word` level leaves six combinations and six trials.
     ...                 constraints=[CoverAllCombinations(color, word),
     ...                              Exclude((word, "red"))])
     CoverAllCombinations(color, word) requires 6 trials.
+    Any of color, word can be moved to `optional`, to be given up for a shorter experiment if no solution is found.
     >>> eb.trials_per_sample()
     6
 
@@ -1225,6 +1228,7 @@ passes.
     >>> nb = Nest(outer_block=outer, inner_block=inner,
     ...           constraints=[CoverAllCombinations(color, word)])
     CoverAllCombinations(color, word) requires 12 trials.
+    Any of color, word can be moved to `optional`, to be given up for a shorter experiment if no solution is found.
     >>> nb.trials_per_sample()
     12
 
@@ -1271,6 +1275,7 @@ the block up to a fourth pass.
     ...                 constraints=[CoverAllCombinations(color, word),
     ...                              Pin(0, (word, "red"))])
     CoverAllCombinations(color, word) requires 12 trials.
+    Any of color, word can be moved to `optional`, to be given up for a shorter experiment if no solution is found.
     >>> pb.trials_per_sample()
     12
 
@@ -1342,35 +1347,47 @@ reported as the block is built, so it is visible without asking for it.
     >>> tb = CrossBlock(design=design, crossing=[task],
     ...                 constraints=[CoverAllCombinations(colr, size, cue)])
     CoverAllCombinations(colr, size, cue) requires 12 trials.
+    Any of colr, size, cue can be moved to `optional`, to be given up for a shorter experiment if no solution is found.
     >>> tb.trials_per_sample()
     12
 
-The `optional` argument names factors that need only each of their own
-levels to appear, in no particular combination. The factors given
-positionally keep the full requirement, so each factor is classified
-once. Making `cue` optional brings the same design down to four trials,
-and the report names what was made optional.
+The `optional` argument names factors that may be *given up* if the
+design turns out to have no solution. It changes nothing on its own:
+coverage still asks for every combination of every listed factor, so
+naming `cue` optional leaves the same twelve trials.
 
   .. doctest::
 
     >>> pb = CrossBlock(design=design, crossing=[task],
     ...                 constraints=[CoverAllCombinations(colr, size,
     ...                                                   optional=[cue])])
-    CoverAllCombinations(colr, size, optional=[cue]) requires 4 trials. (cue: each level appears at least once)
+    CoverAllCombinations(colr, size, optional=[cue]) requires 12 trials.
+    Any of colr, size can be moved to `optional`, to be given up for a shorter experiment if no solution is found.
     >>> pb.trials_per_sample()
-    4
+    12
 
-All four `colr`-`size` combinations still appear and all three `cue`
-levels still appear, but the twelve three-way combinations no longer
-have to. To choose differently, move factors between the two groups and
-build the block again.
+When the solver reports that the design has no solution, factors are
+given up one at a time, the last one named first. A factor that has been
+given up needs only each of its own levels to appear, in no particular
+combination, which usually takes fewer trials --- so the block is
+re-sized after each one, and the new count is reported. Giving `cue` up
+here brings the design down to four trials: all four `colr`-`size`
+combinations still appear and all three `cue` levels still appear, but
+the twelve three-way combinations no longer have to.
 
-A factor may not be in both groups, since it cannot both require its
-combinations and give them up.
+Because factors are given up while the design is being solved, a block's
+trial count is provisional until then. Reading
+:meth:`.trials_per_sample` straight after building a block reports what
+full coverage costs, which is what the block will use if nothing has to
+be given up.
 
-Listing the same factors in two separate constraints expresses the
-same thing without the `optional` argument, since each constraint is
-sized on its own and the block takes the larger count.
+A factor may not be both required and optional, since it cannot both
+require its combinations and give them up.
+
+Listing the same factors in two separate constraints asks for the
+weaker requirement outright, without waiting for a design to fail, since
+each constraint is sized on its own and the block takes the larger
+count.
 
   .. doctest::
 
@@ -1378,6 +1395,7 @@ sized on its own and the block takes the larger count.
     ...                 constraints=[CoverAllCombinations(colr, size),
     ...                              CoverAllCombinations(cue)])
     CoverAllCombinations(colr, size) requires 4 trials.
+    Any of colr, size can be moved to `optional`, to be given up for a shorter experiment if no solution is found.
     CoverAllCombinations(cue) requires 4 trials.
     >>> sb.trials_per_sample()
     4
@@ -1409,6 +1427,7 @@ adjusts it, provided the change stays within the budget.
     ...                 constraints=[CoverAllCombinations(color, word), cap])
     ExactlyK for 'word red' relaxed from 2 to 3, as CoverAllCombinations(color, word) requires.
     CoverAllCombinations(color, word) requires 9 trials.
+    Any of color, word can be moved to `optional`, to be given up for a shorter experiment if no solution is found.
     >>> rb.trials_per_sample()
     9
 

--- a/docs/_source/guide/usage.rst
+++ b/docs/_source/guide/usage.rst
@@ -1316,3 +1316,79 @@ and coverage takes that into account when sizing the block. The levels
 of the factors listed in :class:`.CoverAllCombinations` itself must be
 unweighted, however, since the meaning of a weight on a covered
 combination is not currently defined.
+
+Trading Coverage for Fewer Trials
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The set of combinations to cover is the product of the levels of the
+listed factors, so each factor added to
+:class:`.CoverAllCombinations` multiplies the trial count. Covering
+`colr`, `size`, and `cue` together takes twelve trials.
+
+  .. doctest::
+
+    >>> from sweetpea import Factor, CrossBlock, CoverAllCombinations
+    >>> colr = Factor("colr", ["red", "green"])
+    >>> size = Factor("size", ["big", "small"])
+    >>> cue = Factor("cue", ["c1", "c2", "c3"])
+    >>> task = Factor("task", ["A", "B"])
+    >>> design = [task, colr, size, cue]
+    >>> tb = CrossBlock(design=design, crossing=[task],
+    ...                 constraints=[CoverAllCombinations(colr, size, cue)])
+    >>> tb.trials_per_sample()
+    12
+
+The `prioritize` argument names the factors to keep fully crossed. The
+remaining listed factors are demoted: each of their levels must still
+appear at least once, but their combinations with the other factors
+are no longer required. Keeping `colr` and `size` crossed brings the
+same design down to four trials.
+
+  .. doctest::
+
+    >>> pb = CrossBlock(design=design, crossing=[task],
+    ...                 constraints=[CoverAllCombinations(colr, size, cue,
+    ...                                                   prioritize=[colr, size])])
+    >>> pb.trials_per_sample()
+    4
+
+All four `colr`-`size` combinations still appear and all three `cue`
+levels still appear, but the twelve three-way combinations no longer
+have to.
+
+Passing ``prioritize=True`` asks for that choice while the block is
+being built. SweetPea reports the trial count, and if it is declined,
+asks which factors to keep and reports the new count.
+
+  .. code-block:: text
+
+    CoverAllCombinations(colr, size, cue, prioritize=True) needs 12 trials.
+    Accept? [Y/n] n
+    Which factors should stay fully crossed?
+    (comma-separated, from: colr, size, cue)
+    > colr, size
+    That gives 4 trials. (cue: each level appears at least once)
+
+    CoverAllCombinations(colr, size, cue, prioritize=True) needs 4 trials.
+    Accept? [Y/n] y
+
+    To skip this prompt next time:
+        CoverAllCombinations(colr, size, cue, prioritize=[colr, size])
+
+The prompt ends by printing the equivalent `prioritize` list, because a
+script that asks a question otherwise produces a different design
+depending on what was typed. Where no interactive input is
+available---under a test runner, or a piped script---the prompt is
+skipped with a warning and the full coverage count is used.
+
+Listing the same factors in two separate constraints expresses the
+same thing without the `prioritize` argument, since each constraint is
+sized on its own and the block takes the larger count.
+
+  .. doctest::
+
+    >>> sb = CrossBlock(design=design, crossing=[task],
+    ...                 constraints=[CoverAllCombinations(colr, size),
+    ...                              CoverAllCombinations(cue)])
+    >>> sb.trials_per_sample()
+    4

--- a/docs/_source/guide/usage.rst
+++ b/docs/_source/guide/usage.rst
@@ -1129,6 +1129,7 @@ cannot hold four combinations, so the block grows to four trials.
 
     >>> cb = CrossBlock(design=[task, colr, size], crossing=[task],
     ...                 constraints=[CoverAllCombinations(colr, size)])
+    CoverAllCombinations(colr, size) requires 4 trials.
     >>> cb.trials_per_sample()
     4
 
@@ -1164,6 +1165,7 @@ passes---nine trials---are required.
     >>> word  = Factor("word",  ["red", "green", "blue"])
     >>> b = CrossBlock(design=[color, word], crossing=[color],
     ...                constraints=[CoverAllCombinations(color, word)])
+    CoverAllCombinations(color, word) requires 9 trials.
     >>> b.trials_per_sample()
     9
 
@@ -1195,6 +1197,7 @@ ruling out one `word` level leaves six combinations and six trials.
     >>> eb = CrossBlock(design=[color, word], crossing=[color],
     ...                 constraints=[CoverAllCombinations(color, word),
     ...                              Exclude((word, "red"))])
+    CoverAllCombinations(color, word) requires 6 trials.
     >>> eb.trials_per_sample()
     6
 
@@ -1221,6 +1224,7 @@ passes.
     ...                    constraints=[])
     >>> nb = Nest(outer_block=outer, inner_block=inner,
     ...           constraints=[CoverAllCombinations(color, word)])
+    CoverAllCombinations(color, word) requires 12 trials.
     >>> nb.trials_per_sample()
     12
 
@@ -1266,6 +1270,7 @@ the block up to a fourth pass.
     >>> pb = CrossBlock(design=[color, word], crossing=[color],
     ...                 constraints=[CoverAllCombinations(color, word),
     ...                              Pin(0, (word, "red"))])
+    CoverAllCombinations(color, word) requires 12 trials.
     >>> pb.trials_per_sample()
     12
 
@@ -1323,7 +1328,8 @@ Trading Coverage for Fewer Trials
 The set of combinations to cover is the product of the levels of the
 listed factors, so each factor added to
 :class:`.CoverAllCombinations` multiplies the trial count. Covering
-`colr`, `size`, and `cue` together takes twelve trials.
+`colr`, `size`, and `cue` together takes twelve trials. The count is
+reported as the block is built, so it is visible without asking for it.
 
   .. doctest::
 
@@ -1335,6 +1341,7 @@ listed factors, so each factor added to
     >>> design = [task, colr, size, cue]
     >>> tb = CrossBlock(design=design, crossing=[task],
     ...                 constraints=[CoverAllCombinations(colr, size, cue)])
+    CoverAllCombinations(colr, size, cue) requires 12 trials.
     >>> tb.trials_per_sample()
     12
 
@@ -1342,44 +1349,21 @@ The `prioritize` argument names the factors to keep fully crossed. The
 remaining listed factors are demoted: each of their levels must still
 appear at least once, but their combinations with the other factors
 are no longer required. Keeping `colr` and `size` crossed brings the
-same design down to four trials.
+same design down to four trials, and the report names what was demoted.
 
   .. doctest::
 
     >>> pb = CrossBlock(design=design, crossing=[task],
     ...                 constraints=[CoverAllCombinations(colr, size, cue,
     ...                                                   prioritize=[colr, size])])
+    CoverAllCombinations(colr, size, cue, prioritize=[colr, size]) requires 4 trials. (cue: each level appears at least once)
     >>> pb.trials_per_sample()
     4
 
 All four `colr`-`size` combinations still appear and all three `cue`
 levels still appear, but the twelve three-way combinations no longer
-have to.
-
-Passing ``prioritize=True`` asks for that choice while the block is
-being built. SweetPea reports the trial count, and if it is declined,
-asks which factors to keep and reports the new count.
-
-  .. code-block:: text
-
-    CoverAllCombinations(colr, size, cue, prioritize=True) needs 12 trials.
-    Accept? [Y/n] n
-    Which factors should stay fully crossed?
-    (comma-separated, from: colr, size, cue)
-    > colr, size
-    That gives 4 trials. (cue: each level appears at least once)
-
-    CoverAllCombinations(colr, size, cue, prioritize=True) needs 4 trials.
-    Accept? [Y/n] y
-
-    To skip this prompt next time:
-        CoverAllCombinations(colr, size, cue, prioritize=[colr, size])
-
-The prompt ends by printing the equivalent `prioritize` list, because a
-script that asks a question otherwise produces a different design
-depending on what was typed. Where no interactive input is
-available---under a test runner, or a piped script---the prompt is
-skipped with a warning and the full coverage count is used.
+have to. To choose differently, change the `prioritize` list and build
+the block again.
 
 Listing the same factors in two separate constraints expresses the
 same thing without the `prioritize` argument, since each constraint is
@@ -1390,5 +1374,7 @@ sized on its own and the block takes the larger count.
     >>> sb = CrossBlock(design=design, crossing=[task],
     ...                 constraints=[CoverAllCombinations(colr, size),
     ...                              CoverAllCombinations(cue)])
+    CoverAllCombinations(colr, size) requires 4 trials.
+    CoverAllCombinations(cue) requires 4 trials.
     >>> sb.trials_per_sample()
     4

--- a/docs/_source/guide/usage.rst
+++ b/docs/_source/guide/usage.rst
@@ -1345,28 +1345,31 @@ reported as the block is built, so it is visible without asking for it.
     >>> tb.trials_per_sample()
     12
 
-The `prioritize` argument names the factors to keep fully crossed. The
-remaining listed factors are demoted: each of their levels must still
-appear at least once, but their combinations with the other factors
-are no longer required. Keeping `colr` and `size` crossed brings the
-same design down to four trials, and the report names what was demoted.
+The `optional` argument names factors that need only each of their own
+levels to appear, in no particular combination. The factors given
+positionally keep the full requirement, so each factor is classified
+once. Making `cue` optional brings the same design down to four trials,
+and the report names what was made optional.
 
   .. doctest::
 
     >>> pb = CrossBlock(design=design, crossing=[task],
-    ...                 constraints=[CoverAllCombinations(colr, size, cue,
-    ...                                                   prioritize=[colr, size])])
-    CoverAllCombinations(colr, size, cue, prioritize=[colr, size]) requires 4 trials. (cue: each level appears at least once)
+    ...                 constraints=[CoverAllCombinations(colr, size,
+    ...                                                   optional=[cue])])
+    CoverAllCombinations(colr, size, optional=[cue]) requires 4 trials. (cue: each level appears at least once)
     >>> pb.trials_per_sample()
     4
 
 All four `colr`-`size` combinations still appear and all three `cue`
 levels still appear, but the twelve three-way combinations no longer
-have to. To choose differently, change the `prioritize` list and build
-the block again.
+have to. To choose differently, move factors between the two groups and
+build the block again.
+
+A factor may not be in both groups, since it cannot both require its
+combinations and give them up.
 
 Listing the same factors in two separate constraints expresses the
-same thing without the `prioritize` argument, since each constraint is
+same thing without the `optional` argument, since each constraint is
 sized on its own and the block takes the larger count.
 
   .. doctest::

--- a/docs/_source/guide/usage.rst
+++ b/docs/_source/guide/usage.rst
@@ -1086,9 +1086,9 @@ some combinations may never show up at all.
 The :class:`.CoverAllCombinations` constraint asks for a weaker
 guarantee than crossing: over the experiment as a whole, every
 combination of the listed factors must appear at least once.
-Individual trials still vary freely, and the design itself implies no
-particular number of trials, so SweetPea computes how many trials
-coverage needs and grows the block to fit.
+It says nothing about which trial holds which combination, and the
+design itself implies no particular number of trials, so SweetPea
+computes how many trials coverage needs and grows the block to fit.
 
 A Free-Factor Example
 ^^^^^^^^^^^^^^^^^^^^^

--- a/sweetpea/_internal/base_constraint.py
+++ b/sweetpea/_internal/base_constraint.py
@@ -54,6 +54,12 @@ class Constraint(ABC):
     def init_within_block(self, within_block) -> None:
         pass
 
+    def set_within_block(self, within_block) -> None:
+        """Replace the geometry, where `init_within_block` only fills an empty
+        one. A block resizing itself calls this on the constraints it owns; a
+        constraint shared with an inner block is left alone."""
+        pass
+
     def sustain_within_block(self, sustain_count: int) -> None:
         pass
 

--- a/sweetpea/_internal/block.py
+++ b/sweetpea/_internal/block.py
@@ -78,6 +78,9 @@ class Block:
         self.excluded_derived = cast(List[Dict[Factor, SimpleLevel]], [])
         self.require_complete_crossing = require_complete_crossing
         self.errors = cast(Set[str], set())
+        # Filled in by coverage sizing when `Relax` authorizes a widening;
+        # reported as the block is built and again with the results.
+        self.applied_relaxations = cast(List[str], [])
         self.act_design = list(filter(lambda f: not self.factor_is_implied(f), self.design))
         self._trials_per_sample = None
         self._simple_tuples = cast(Optional[List[Tuple[Factor, Union[SimpleLevel, DerivedLevel]]]], None)

--- a/sweetpea/_internal/constraint.py
+++ b/sweetpea/_internal/constraint.py
@@ -1274,75 +1274,58 @@ def _val_name(x):
 
 class CoverAllCombinations(Constraint):
     """Requires that the trials of an experiment collectively include every realizable
-    combination of `factors` at least once, or a weaker requirement where
-    `prioritize` names only some of them.
+    combination of `factors` at least once, plus a weaker requirement for each
+    factor named in `optional`.
 
     Factors left out of a crossing are otherwise assigned freely by the solver; this
     constraint coordinates those free choices so that the union of all trials covers
     every combination. The number of trials needed is computed automatically and the
     block is grown to fit (see the auto-sizing notes on the block constructors).
 
-    The two arguments do different jobs: `factors` sets what the constraint
-    governs, and `prioritize` sets how strongly. A factor named in `prioritize`
-    must appear in combination with the others named there; a factor left out of
-    it needs only each of its own levels to appear somewhere, in no particular
-    combination. Naming none of them---the default---requires every combination
-    of `factors`, and naming a subset trades coverage for a shorter experiment.
+    The two groups carry different guarantees. The positional `factors` must
+    appear in combination with one another---every combination of their levels.
+    A factor named in `optional` needs only each of its own levels to appear
+    somewhere, in no particular combination, which trades coverage for a shorter
+    experiment. A factor may not be in both groups.
 
     Usage::
 
         Nest(outer, inner, [CoverAllCombinations(color, word)])
         CrossBlock(design, crossing, [CoverAllCombinations(color, word)])
-        CrossBlock(design, crossing, [CoverAllCombinations(color, word, cue,
-                                                           prioritize=[color, word])])
+        CrossBlock(design, crossing, [CoverAllCombinations(color, word,
+                                                           optional=[cue])])
     """
 
-    def __init__(self, *factors, prioritize=[]):
+    def __init__(self, *factors, optional=[]):
         who = "CoverAllCombinations"
-        factor_list = list(factors)
-        if factor_list == []:
-            raise ValueError(who, "factor list must be non-empty")
-        argcheck(who, factor_list, make_islistof(Factor), "factors")
-        self.factors = factor_list
+        required = list(factors)
+        argcheck(who, required, make_islistof(Factor), "factors")
         # Checked before list(), so that a non-iterable (e.g. a stray boolean)
         # reports the parameter by name instead of raising from the conversion.
-        argcheck(who, prioritize, make_islistof(Factor), "prioritize")
-        priority = list(prioritize)
-        self._check_priority(priority, who)
-        self.prioritize = priority
-        # Coverage requirements, one fully-crossed combination set per group.
-        # The lone default group is the full cross of `factors`; a priority list
-        # splits it into the kept group plus a singleton per demoted factor.
-        self.groups = (self._grouping_for(priority) if priority
-                       else cast(List[List[Factor]], [factor_list]))
+        argcheck(who, optional, make_islistof(Factor), "optional")
+        self.required = required
+        self.optional = cast(List[Factor], [])
+        for f in optional:
+            if f in required:
+                raise ValueError((who,
+                                  "'{}' is both required and optional; a factor belongs "
+                                  "to one group or the other".format(f.name)))
+            if f not in self.optional:
+                self.optional.append(f)
+        # Every factor the constraint governs, whichever guarantee it carries.
+        self.factors = self.required + self.optional
+        if self.factors == []:
+            raise ValueError(who, "factor list must be non-empty")
+        # Coverage requirements, one fully-crossed combination set per group:
+        # the required factors together, then each optional factor on its own so
+        # that only its individual levels have to appear.
+        self.groups = cast(List[List[Factor]],
+                           ([required] if required else [])
+                           + [[f] for f in self.optional])
         # Set by Nest during construction: the inner block whose crossing determines
         # which listed factors are pinned vs. free. None for other block types, in
         # which case the attached block itself is analyzed.
         self._inner_block = cast(Optional[MultiCrossBlockRepeat], None)
-
-    # ~~~~~~~~~~~~~~ Priority grouping ~~~~~~~~~~~~~~
-
-    def _check_priority(self, priority, who) -> None:
-        for f in priority:
-            if f not in self.factors:
-                raise ValueError((who,
-                                  "'{}' is not one of the factors listed in the constraint "
-                                  "({})".format(f.name,
-                                                ", ".join(g.name for g in self.factors))))
-
-    def _grouping_for(self, priority) -> List[List[Factor]]:
-        """Groups for a priority list: the named factors form one fully-crossed
-        group, and each remaining listed factor becomes a group of its own, so
-        only its individual levels are required to appear.
-
-        An empty priority list demotes everything, which is the cheapest
-        grouping; naming every factor reproduces the default single group."""
-        kept = []  # type: List[Factor]
-        for f in priority:
-            if f not in kept:
-                kept.append(f)
-        demoted = [f for f in self.factors if f not in kept]
-        return ([kept] if kept else []) + [[f] for f in demoted]
 
     # ~~~~~~~~~~~~~~ Coverage analysis (the "K" computation) ~~~~~~~~~~~~~~
 
@@ -1633,15 +1616,11 @@ class CoverAllCombinations(Constraint):
                           "the other constraints ({})".format(cap, ", ".join(conflicting))))
 
     def sizing_message(self, total) -> str:
-        """The line a block reports as it grows itself for coverage.
-
-        Demoted factors come from `prioritize` rather than from group sizes: a
-        single prioritized factor leaves the kept group a singleton too, so
-        group size cannot tell kept from demoted."""
+        """The line a block reports as it grows itself for coverage."""
         msg = "{} requires {} trials.".format(repr(self), total)
-        demoted = [str(f.name) for f in self.factors if f not in self.prioritize]
-        if self.prioritize and demoted:
-            msg += " ({}: each level appears at least once)".format(", ".join(demoted))
+        if self.optional:
+            msg += " ({}: each level appears at least once)".format(
+                ", ".join(str(f.name) for f in self.optional))
         return msg
 
     @staticmethod
@@ -1730,12 +1709,11 @@ class CoverAllCombinations(Constraint):
     def desugar(self, replacements: dict) -> List[Constraint]:
         def replace(fs):
             return [replacements.get(f, [f, f])[1] for f in fs]
-        c = CoverAllCombinations(*replace(self.factors))
-        c.prioritize = replace(self.prioritize)
-        # Groups hold the same Factor objects as `factors`, so they need the
-        # same mapping: otherwise a weighted design keeps pre-desugar factors
-        # here and coverage is computed against factors the block no longer has.
-        c.groups = [replace(g) for g in self.groups]
+        # Rebuilding through the constructor re-derives the groups from the
+        # mapped factors, so no group can keep a pre-desugar factor that the
+        # block no longer has.
+        c = CoverAllCombinations(*replace(self.required),
+                                 optional=replace(self.optional))
         c._inner_block = self._inner_block
         return [c]
 
@@ -1799,8 +1777,8 @@ class CoverAllCombinations(Constraint):
         return True
 
     def __repr__(self):
-        args = [f.name for f in self.factors]
-        if self.prioritize:
-            args.append("prioritize=[{}]".format(
-                ", ".join(f.name for f in self.prioritize)))
+        args = [f.name for f in self.required]
+        if self.optional:
+            args.append("optional=[{}]".format(
+                ", ".join(f.name for f in self.optional)))
         return "CoverAllCombinations({})".format(", ".join(args))

--- a/sweetpea/_internal/constraint.py
+++ b/sweetpea/_internal/constraint.py
@@ -1,7 +1,6 @@
 """This module provides constraints for CNF generation."""
 
 import operator as op
-import warnings
 from abc import abstractmethod
 from copy import deepcopy
 from typing import List, Tuple, Any, Union, cast, Dict, Callable, Optional
@@ -1273,36 +1272,22 @@ def _val_name(x):
     return getattr(x, "name", x)
 
 
-class _NoInput(Exception):
-    """Raised when a prompt cannot be answered because no interactive input is
-    available: pytest, CI, or a piped script."""
-
-
-def _prompt(message: str) -> str:
-    """Read one line of interactive input, or raise `_NoInput`.
-
-    Availability is decided by attempting the read rather than by consulting
-    `sys.stdin.isatty()`, which reports False under Jupyter---a normal place to
-    build a design, and one where prompting does work."""
-    try:
-        return input(message)
-    except (EOFError, OSError):
-        raise _NoInput()
-
-
 class CoverAllCombinations(Constraint):
     """Requires that the trials of an experiment collectively include every realizable
-    combination of `factors` at least once.
+    combination of `factors` at least once, or a weaker requirement where
+    `prioritize` names only some of them.
 
     Factors left out of a crossing are otherwise assigned freely by the solver; this
     constraint coordinates those free choices so that the union of all trials covers
     every combination. The number of trials needed is computed automatically and the
     block is grown to fit (see the auto-sizing notes on the block constructors).
 
-    `prioritize` trades coverage for a shorter experiment. Given a list of the
-    listed factors, those stay fully crossed and each remaining factor is
-    demoted to needing only each of its own levels present. `True` negotiates
-    that choice interactively as the block is built.
+    The two arguments do different jobs: `factors` sets what the constraint
+    governs, and `prioritize` sets how strongly. A factor named in `prioritize`
+    must appear in combination with the others named there; a factor left out of
+    it needs only each of its own levels to appear somewhere, in no particular
+    combination. Naming none of them---the default---requires every combination
+    of `factors`, and naming a subset trades coverage for a shorter experiment.
 
     Usage::
 
@@ -1312,25 +1297,24 @@ class CoverAllCombinations(Constraint):
                                                            prioritize=[color, word])])
     """
 
-    def __init__(self, *factors, prioritize=False):
+    def __init__(self, *factors, prioritize=[]):
         who = "CoverAllCombinations"
         factor_list = list(factors)
         if factor_list == []:
             raise ValueError(who, "factor list must be non-empty")
         argcheck(who, factor_list, make_islistof(Factor), "factors")
         self.factors = factor_list
+        # Checked before list(), so that a non-iterable (e.g. a stray boolean)
+        # reports the parameter by name instead of raising from the conversion.
+        argcheck(who, prioritize, make_islistof(Factor), "prioritize")
+        priority = list(prioritize)
+        self._check_priority(priority, who)
+        self.prioritize = priority
         # Coverage requirements, one fully-crossed combination set per group.
         # The lone default group is the full cross of `factors`; a priority list
         # splits it into the kept group plus a singleton per demoted factor.
-        self.groups = cast(List[List[Factor]], [factor_list])
-        if isinstance(prioritize, (list, tuple)):
-            priority = list(prioritize)
-            argcheck(who, priority, make_islistof(Factor), "prioritize")
-            self._check_priority(priority, who)
-            self.prioritize = cast(Union[bool, List[Factor]], priority)
-            self.groups = self._grouping_for(priority)
-        else:
-            self.prioritize = cast(Union[bool, List[Factor]], bool(prioritize))
+        self.groups = (self._grouping_for(priority) if priority
+                       else cast(List[List[Factor]], [factor_list]))
         # Set by Nest during construction: the inner block whose crossing determines
         # which listed factors are pinned vs. free. None for other block types, in
         # which case the attached block itself is analyzed.
@@ -1648,68 +1632,17 @@ class CoverAllCombinations(Constraint):
                           "no trial count up to {} instances reconciles coverage with "
                           "the other constraints ({})".format(cap, ", ".join(conflicting))))
 
-    # ~~~~~~~~~~~~~~ Interactive priority negotiation ~~~~~~~~~~~~~~
+    def sizing_message(self, total) -> str:
+        """The line a block reports as it grows itself for coverage.
 
-    def negotiate_trials(self, block) -> int:
-        """`autosize_trials`, plus the interactive negotiation that
-        ``prioritize=True`` asks for. Separate so that `autosize_trials` stays a
-        pure computation the negotiation can re-run per candidate grouping."""
-        total = self.autosize_trials(block)
-        if self.prioritize is not True or len(self.factors) < 2:
-            # A single listed factor has nothing to demote.
-            return total
-        names = ", ".join(f.name for f in self.factors)
-        by_name = {f.name: f for f in self.factors}
-        chosen = cast(Optional[List[Factor]], None)
-        try:
-            while True:
-                answer = _prompt("\n{} needs {} trials.\nAccept? [Y/n] ".format(
-                    repr(self), total))
-                if answer.strip().lower() not in ("n", "no"):
-                    break
-                while True:
-                    raw = _prompt("Which factors should stay fully crossed?\n"
-                                  "(comma-separated, from: {})\n> ".format(names))
-                    wanted = [w.strip() for w in raw.split(",") if w.strip()]
-                    unknown = [w for w in wanted if w not in by_name]
-                    if not unknown:
-                        break
-                    print("Not listed in this constraint: {}.".format(", ".join(unknown)))
-                priority = [by_name[w] for w in wanted]
-                candidate = self._grouping_for(priority)
-                saved = self.groups
-                self.groups = candidate
-                try:
-                    total = self.autosize_trials(block)
-                except ValueError as e:
-                    # Reject the candidate rather than aborting the whole block:
-                    # the user can still pick a grouping that reconciles.
-                    self.groups = saved
-                    total = self.autosize_trials(block)
-                    print("That grouping cannot be reconciled: {}".format(e))
-                    continue
-                chosen = priority
-                demoted = [str(g[0].name) for g in candidate
-                           if len(g) == 1 and g[0] not in priority]
-                if demoted:
-                    print("That gives {} trials. ({}: each level appears at least "
-                          "once)".format(total, ", ".join(demoted)))
-                else:
-                    print("That gives {} trials.".format(total))
-        except _NoInput:
-            self.groups = [self.factors]
-            total = self.autosize_trials(block)
-            warnings.warn("CoverAllCombinations: no interactive input available, so the "
-                          "prioritize=True prompt was skipped; using the computed trial "
-                          "count of {}".format(total))
-            return total
-        if chosen is not None:
-            # An interactive design is otherwise unreproducible: re-running the
-            # script re-prompts, and the result depends on what was typed.
-            print("\nTo skip this prompt next time:\n    CoverAllCombinations({}, "
-                  "prioritize=[{}])".format(", ".join(str(f.name) for f in self.factors),
-                                            ", ".join(str(f.name) for f in chosen)))
-        return total
+        Demoted factors come from `prioritize` rather than from group sizes: a
+        single prioritized factor leaves the kept group a singleton too, so
+        group size cannot tell kept from demoted."""
+        msg = "{} requires {} trials.".format(repr(self), total)
+        demoted = [str(f.name) for f in self.factors if f not in self.prioritize]
+        if self.prioritize and demoted:
+            msg += " ({}: each level appears at least once)".format(", ".join(demoted))
+        return msg
 
     @staticmethod
     def _k_lower_bound(R_free, slots, slot_weights=None):
@@ -1798,8 +1731,7 @@ class CoverAllCombinations(Constraint):
         def replace(fs):
             return [replacements.get(f, [f, f])[1] for f in fs]
         c = CoverAllCombinations(*replace(self.factors))
-        c.prioritize = (replace(self.prioritize)
-                        if isinstance(self.prioritize, list) else self.prioritize)
+        c.prioritize = replace(self.prioritize)
         # Groups hold the same Factor objects as `factors`, so they need the
         # same mapping: otherwise a weighted design keeps pre-desugar factors
         # here and coverage is computed against factors the block no longer has.
@@ -1868,9 +1800,7 @@ class CoverAllCombinations(Constraint):
 
     def __repr__(self):
         args = [f.name for f in self.factors]
-        if isinstance(self.prioritize, list):
+        if self.prioritize:
             args.append("prioritize=[{}]".format(
                 ", ".join(f.name for f in self.prioritize)))
-        elif self.prioritize:
-            args.append("prioritize=True")
         return "CoverAllCombinations({})".format(", ".join(args))

--- a/sweetpea/_internal/constraint.py
+++ b/sweetpea/_internal/constraint.py
@@ -1,6 +1,7 @@
 """This module provides constraints for CNF generation."""
 
 import operator as op
+import warnings
 from abc import abstractmethod
 from copy import deepcopy
 from typing import List, Tuple, Any, Union, cast, Dict, Callable, Optional
@@ -1272,6 +1273,23 @@ def _val_name(x):
     return getattr(x, "name", x)
 
 
+class _NoInput(Exception):
+    """Raised when a prompt cannot be answered because no interactive input is
+    available: pytest, CI, or a piped script."""
+
+
+def _prompt(message: str) -> str:
+    """Read one line of interactive input, or raise `_NoInput`.
+
+    Availability is decided by attempting the read rather than by consulting
+    `sys.stdin.isatty()`, which reports False under Jupyter---a normal place to
+    build a design, and one where prompting does work."""
+    try:
+        return input(message)
+    except (EOFError, OSError):
+        raise _NoInput()
+
+
 class CoverAllCombinations(Constraint):
     """Requires that the trials of an experiment collectively include every realizable
     combination of `factors` at least once.
@@ -1281,23 +1299,66 @@ class CoverAllCombinations(Constraint):
     every combination. The number of trials needed is computed automatically and the
     block is grown to fit (see the auto-sizing notes on the block constructors).
 
+    `prioritize` trades coverage for a shorter experiment. Given a list of the
+    listed factors, those stay fully crossed and each remaining factor is
+    demoted to needing only each of its own levels present. `True` negotiates
+    that choice interactively as the block is built.
+
     Usage::
 
         Nest(outer, inner, [CoverAllCombinations(color, word)])
         CrossBlock(design, crossing, [CoverAllCombinations(color, word)])
+        CrossBlock(design, crossing, [CoverAllCombinations(color, word, cue,
+                                                           prioritize=[color, word])])
     """
 
-    def __init__(self, *factors):
+    def __init__(self, *factors, prioritize=False):
         who = "CoverAllCombinations"
         factor_list = list(factors)
         if factor_list == []:
             raise ValueError(who, "factor list must be non-empty")
         argcheck(who, factor_list, make_islistof(Factor), "factors")
         self.factors = factor_list
+        # Coverage requirements, one fully-crossed combination set per group.
+        # The lone default group is the full cross of `factors`; a priority list
+        # splits it into the kept group plus a singleton per demoted factor.
+        self.groups = cast(List[List[Factor]], [factor_list])
+        if isinstance(prioritize, (list, tuple)):
+            priority = list(prioritize)
+            argcheck(who, priority, make_islistof(Factor), "prioritize")
+            self._check_priority(priority, who)
+            self.prioritize = cast(Union[bool, List[Factor]], priority)
+            self.groups = self._grouping_for(priority)
+        else:
+            self.prioritize = cast(Union[bool, List[Factor]], bool(prioritize))
         # Set by Nest during construction: the inner block whose crossing determines
         # which listed factors are pinned vs. free. None for other block types, in
         # which case the attached block itself is analyzed.
         self._inner_block = cast(Optional[MultiCrossBlockRepeat], None)
+
+    # ~~~~~~~~~~~~~~ Priority grouping ~~~~~~~~~~~~~~
+
+    def _check_priority(self, priority, who) -> None:
+        for f in priority:
+            if f not in self.factors:
+                raise ValueError((who,
+                                  "'{}' is not one of the factors listed in the constraint "
+                                  "({})".format(f.name,
+                                                ", ".join(g.name for g in self.factors))))
+
+    def _grouping_for(self, priority) -> List[List[Factor]]:
+        """Groups for a priority list: the named factors form one fully-crossed
+        group, and each remaining listed factor becomes a group of its own, so
+        only its individual levels are required to appear.
+
+        An empty priority list demotes everything, which is the cheapest
+        grouping; naming every factor reproduces the default single group."""
+        kept = []  # type: List[Factor]
+        for f in priority:
+            if f not in kept:
+                kept.append(f)
+        demoted = [f for f in self.factors if f not in kept]
+        return ([kept] if kept else []) + [[f] for f in demoted]
 
     # ~~~~~~~~~~~~~~ Coverage analysis (the "K" computation) ~~~~~~~~~~~~~~
 
@@ -1336,11 +1397,11 @@ class CoverAllCombinations(Constraint):
                         return True
         return False
 
-    def _coverage_analysis(self, block, exclusion_block=None):
-        """Structural analysis over `self.factors` for the given analysis block.
-        When `exclusion_block` is given (e.g. the merged block of a Nest), its
-        exclusions are folded into realizability as well, so that an Exclude at
-        any level simply removes combinations from the required set.
+    def _coverage_analysis(self, block, factors, exclusion_block=None):
+        """Structural analysis over `factors` (one coverage group) for the given
+        analysis block. When `exclusion_block` is given (e.g. the merged block of
+        a Nest), its exclusions are folded into realizability as well, so that an
+        Exclude at any level simply removes combinations from the required set.
 
         Returns ``(R, forced, R_free, slots, combo_levels, slot_weights,
         forced_weights)`` where:
@@ -1358,7 +1419,7 @@ class CoverAllCombinations(Constraint):
         - ``forced_weights``: per forced combo, its occurrences per instance
           (sum of the combination weights of the cells that force it).
         """
-        listed = self.factors
+        listed = factors
         crossing_factors = self._cell_factors(block)
         if not crossing_factors:
             return (set(), set(), set(), [], {}, [], {})
@@ -1410,11 +1471,16 @@ class CoverAllCombinations(Constraint):
         return (R, forced, R_free, slots, combo_levels, slot_weights, forced_weights)
 
     def required_instances(self, block=None):
-        """Minimum number of instances (K) needed to cover ``R_free``."""
+        """Minimum number of instances (K) needed to cover ``R_free``, over the
+        largest of the coverage groups."""
         if block is None:
             block = self._inner_block
-        (_, _, R_free, slots, _, slot_weights, _) = self._coverage_analysis(block)
-        return self._min_instances(R_free, slots, slot_weights)
+        k = 1
+        for group in self.groups:
+            (_, _, R_free, slots, _, slot_weights, _) = \
+                self._coverage_analysis(block, group)
+            k = max(k, self._min_instances(R_free, slots, slot_weights))
+        return k
 
     def _relevant_constraints(self, sizing_block):
         """The sizing block's constraints that are statically reconciled into the
@@ -1505,9 +1571,53 @@ class CoverAllCombinations(Constraint):
         for c in analysis.crossings:
             if c is not cell_crossing and any(f in c for f in self.factors):
                 return 0
-        (R, forced, R_free, slots, _, slot_weights, forced_weights) = \
-            self._coverage_analysis(analysis, exclusion_block=block)
         (pins, caps, seqs) = self._relevant_constraints(block)
+        if analysis is not block:
+            # Nest: one instance = one inner-block pass.
+            instance_len = analysis.trials_per_sample() - analysis.common_preamble_size()
+        else:
+            # crossing_size already folds in the crossing's sustain count.
+            instance_len = block.crossing_size(cell_crossing)
+        if instance_len <= 0:
+            return 0
+        # Sequential enrichment applies to listed factors the cells leave free.
+        cell_factors = self._cell_factors(analysis)
+        seq_free = [ct for ct in seqs if ct.factor not in cell_factors]
+        # Each group is sized on its own and the block takes the largest K: one
+        # trial serves one combination from every group at once, so the groups
+        # do not add up. A priority list only ever produces groups that are
+        # disjoint in the factors the cells leave free, so the per-group counts
+        # are independent and the largest is exact rather than a lower bound.
+        k = 1
+        for group in self.groups:
+            k = max(k, self._instances_for_group(block, analysis, group, instance_len,
+                                                 pins, caps, seq_free, who))
+        total = k * instance_len
+        # Round up to complete passes of every crossing. Iterating settles on a
+        # common multiple; the iteration bound avoids chasing a large LCM when
+        # pass lengths are co-prime. crossing_size already folds in sustain.
+        passes = [block.crossing_size(c) for c in block.crossings]
+        for _ in range(4):
+            rounded = total
+            for p in passes:
+                if p > 0 and rounded % p != 0:
+                    rounded = ((rounded // p) + 1) * p
+            if rounded == total:
+                break
+            total = rounded
+        return total
+
+    def _instances_for_group(self, block, analysis, group, instance_len,
+                             pins, caps, seq_free, who) -> int:
+        """Instances (K) needed for one coverage group, with the statically
+        modeled effects of the block's other constraints folded in.
+
+        The ExactlyK arithmetic here counts one group's requirements. Across
+        several groups it therefore under-counts a level's total demand; the
+        residual is left to the solver, as the in-a-row family and LatinSquare
+        already are."""
+        (R, forced, R_free, slots, _, slot_weights, forced_weights) = \
+            self._coverage_analysis(analysis, group, exclusion_block=block)
         # Definitive check: `required` = the capped level's occurrences at K=1
         # (each free combo at least once + each forced combo at its per-instance
         # weight). Adding instances only increases the forced term, so a cap
@@ -1523,17 +1633,6 @@ class CoverAllCombinations(Constraint):
                                   "with '{} {}' but an ExactlyK constraint allows exactly "
                                   "{}".format(required, fname, lname, ct.k)))
         k_opt = self._min_instances(R_free, slots, slot_weights)
-        if analysis is not block:
-            # Nest: one instance = one inner-block pass.
-            instance_len = analysis.trials_per_sample() - analysis.common_preamble_size()
-        else:
-            # crossing_size already folds in the crossing's sustain count.
-            instance_len = block.crossing_size(cell_crossing)
-        if instance_len <= 0:
-            return 0
-        # Sequential enrichment applies to listed factors the cells leave free.
-        cell_factors = self._cell_factors(analysis)
-        seq_free = [ct for ct in seqs if ct.factor not in cell_factors]
         # Scan ceiling: |R_free| instances provably suffice for the plain model
         # (see _min_instances), so twice that (or twice k_opt) leaves headroom
         # for what constraints consume; exhausting it => irreconcilable.
@@ -1542,26 +1641,74 @@ class CoverAllCombinations(Constraint):
         while k <= cap:
             if self._feasible_at(k, instance_len, R_free, forced, slots, pins, caps,
                                  seq_free, block, slot_weights, forced_weights):
-                break
+                return k
             k += 1
-        else:
-            conflicting = [repr(ct) for ct in (pins + caps + seq_free)]
-            raise ValueError((who,
-                              "no trial count up to {} instances reconciles coverage with "
-                              "the other constraints ({})".format(cap, ", ".join(conflicting))))
-        total = k * instance_len
-        # Round up to complete passes of every crossing. Iterating settles on a
-        # common multiple; the iteration bound avoids chasing a large LCM when
-        # pass lengths are co-prime. crossing_size already folds in sustain.
-        passes = [block.crossing_size(c) for c in block.crossings]
-        for _ in range(4):
-            rounded = total
-            for p in passes:
-                if p > 0 and rounded % p != 0:
-                    rounded = ((rounded // p) + 1) * p
-            if rounded == total:
-                break
-            total = rounded
+        conflicting = [repr(ct) for ct in (pins + caps + seq_free)]
+        raise ValueError((who,
+                          "no trial count up to {} instances reconciles coverage with "
+                          "the other constraints ({})".format(cap, ", ".join(conflicting))))
+
+    # ~~~~~~~~~~~~~~ Interactive priority negotiation ~~~~~~~~~~~~~~
+
+    def negotiate_trials(self, block) -> int:
+        """`autosize_trials`, plus the interactive negotiation that
+        ``prioritize=True`` asks for. Separate so that `autosize_trials` stays a
+        pure computation the negotiation can re-run per candidate grouping."""
+        total = self.autosize_trials(block)
+        if self.prioritize is not True or len(self.factors) < 2:
+            # A single listed factor has nothing to demote.
+            return total
+        names = ", ".join(f.name for f in self.factors)
+        by_name = {f.name: f for f in self.factors}
+        chosen = cast(Optional[List[Factor]], None)
+        try:
+            while True:
+                answer = _prompt("\n{} needs {} trials.\nAccept? [Y/n] ".format(
+                    repr(self), total))
+                if answer.strip().lower() not in ("n", "no"):
+                    break
+                while True:
+                    raw = _prompt("Which factors should stay fully crossed?\n"
+                                  "(comma-separated, from: {})\n> ".format(names))
+                    wanted = [w.strip() for w in raw.split(",") if w.strip()]
+                    unknown = [w for w in wanted if w not in by_name]
+                    if not unknown:
+                        break
+                    print("Not listed in this constraint: {}.".format(", ".join(unknown)))
+                priority = [by_name[w] for w in wanted]
+                candidate = self._grouping_for(priority)
+                saved = self.groups
+                self.groups = candidate
+                try:
+                    total = self.autosize_trials(block)
+                except ValueError as e:
+                    # Reject the candidate rather than aborting the whole block:
+                    # the user can still pick a grouping that reconciles.
+                    self.groups = saved
+                    total = self.autosize_trials(block)
+                    print("That grouping cannot be reconciled: {}".format(e))
+                    continue
+                chosen = priority
+                demoted = [str(g[0].name) for g in candidate
+                           if len(g) == 1 and g[0] not in priority]
+                if demoted:
+                    print("That gives {} trials. ({}: each level appears at least "
+                          "once)".format(total, ", ".join(demoted)))
+                else:
+                    print("That gives {} trials.".format(total))
+        except _NoInput:
+            self.groups = [self.factors]
+            total = self.autosize_trials(block)
+            warnings.warn("CoverAllCombinations: no interactive input available, so the "
+                          "prioritize=True prompt was skipped; using the computed trial "
+                          "count of {}".format(total))
+            return total
+        if chosen is not None:
+            # An interactive design is otherwise unreproducible: re-running the
+            # script re-prompts, and the result depends on what was typed.
+            print("\nTo skip this prompt next time:\n    CoverAllCombinations({}, "
+                  "prioritize=[{}])".format(", ".join(str(f.name) for f in self.factors),
+                                            ", ".join(str(f.name) for f in chosen)))
         return total
 
     @staticmethod
@@ -1648,8 +1795,15 @@ class CoverAllCombinations(Constraint):
         return any(factor.uses_factor(f) for factor in self.factors)
 
     def desugar(self, replacements: dict) -> List[Constraint]:
-        factors = [replacements.get(f, [f, f])[1] for f in self.factors]
-        c = CoverAllCombinations(*factors)
+        def replace(fs):
+            return [replacements.get(f, [f, f])[1] for f in fs]
+        c = CoverAllCombinations(*replace(self.factors))
+        c.prioritize = (replace(self.prioritize)
+                        if isinstance(self.prioritize, list) else self.prioritize)
+        # Groups hold the same Factor objects as `factors`, so they need the
+        # same mapping: otherwise a weighted design keeps pre-desugar factors
+        # here and coverage is computed against factors the block no longer has.
+        c.groups = [replace(g) for g in self.groups]
         c._inner_block = self._inner_block
         return [c]
 
@@ -1665,48 +1819,58 @@ class CoverAllCombinations(Constraint):
             validate_factor(block, f)
 
     def apply(self, block: Block, backend_request: BackendRequest) -> None:
-        (_, _, R_free, _, combo_levels, _, _) = self._coverage_analysis(
-            self._analysis_block(block), exclusion_block=block)
-        if not R_free:
-            return
         preamble = block.common_preamble_size()
         num_trials = block.trials_per_sample()
         trials = list(range(1 + preamble, num_trials + 1))
 
         fresh = backend_request.fresh
         formula_parts = cast(List[FormulaWithIff], [])
-        for combo in R_free:
-            levels = combo_levels[combo]
-            state_vars = []
-            for t in trials:
-                sv = fresh
-                fresh += 1
-                state_vars.append(sv)
-                formula_parts.append(Iff(sv, And(list(block.encode_combination(levels, t)))))
-            # At least one trial must instantiate this combination.
-            formula_parts.append(Or(state_vars))
+        analysis = self._analysis_block(block)
+        for group in self.groups:
+            (_, _, R_free, _, combo_levels, _, _) = self._coverage_analysis(
+                analysis, group, exclusion_block=block)
+            # A group's combinations name only its own factors, so a demoted
+            # singleton asks for its level alone; encode_combination takes the
+            # partial assignment as-is.
+            for combo in R_free:
+                levels = combo_levels[combo]
+                state_vars = []
+                for t in trials:
+                    sv = fresh
+                    fresh += 1
+                    state_vars.append(sv)
+                    formula_parts.append(Iff(sv, And(list(block.encode_combination(levels, t)))))
+                # At least one trial must instantiate this combination.
+                formula_parts.append(Or(state_vars))
+        if not formula_parts:
+            return
 
         (cnf, new_fresh) = block.cnf_fn(And(formula_parts), fresh)
         backend_request.cnfs.append(cnf)
         backend_request.fresh = new_fresh
 
     def potential_sample_conforms(self, sample: dict, block: Block) -> bool:
-        (_, _, R_free, _, _, _, _) = self._coverage_analysis(
-            self._analysis_block(block), exclusion_block=block)
-        if not R_free:
-            return True
         num_trials = block.trials_per_sample()
-        for combo in R_free:
-            need = dict(combo)  # factor_name -> level_name
-            found = False
-            for t in range(num_trials):
-                if all(sample[f][t].name == need[f.name] for f in self.factors):
-                    found = True
-                    break
-            if not found:
-                return False
+        analysis = self._analysis_block(block)
+        for group in self.groups:
+            (_, _, R_free, _, _, _, _) = self._coverage_analysis(
+                analysis, group, exclusion_block=block)
+            for combo in R_free:
+                need = dict(combo)  # factor_name -> level_name
+                found = False
+                for t in range(num_trials):
+                    if all(sample[f][t].name == need[f.name] for f in group):
+                        found = True
+                        break
+                if not found:
+                    return False
         return True
 
     def __repr__(self):
-        return "CoverAllCombinations({})".format(
-            ", ".join([f.name for f in self.factors]))
+        args = [f.name for f in self.factors]
+        if isinstance(self.prioritize, list):
+            args.append("prioritize=[{}]".format(
+                ", ".join(f.name for f in self.prioritize)))
+        elif self.prioritize:
+            args.append("prioritize=True")
+        return "CoverAllCombinations({})".format(", ".join(args))

--- a/sweetpea/_internal/constraint.py
+++ b/sweetpea/_internal/constraint.py
@@ -2,7 +2,7 @@
 
 import operator as op
 from abc import abstractmethod
-from copy import deepcopy
+from copy import copy, deepcopy
 from typing import List, Tuple, Any, Union, cast, Dict, Callable, Optional
 from itertools import chain, product
 from math import ceil
@@ -382,10 +382,16 @@ class Derivation(Constraint):
 
 
 class _KInARow(Constraint):
+    #: How `k` moves to weaken this constraint: +1 raises it, -1 lowers it.
+    #: Zero means the solver loop cannot step it.
+    weaken_step = 0
+
     def __init__(self, k, level):
         self.k = k
         self.level = level
         self.within_block = cast(Optional[BlockGeometry], None)
+        # Set by `Relax`; None means the constraint is binding.
+        self.relaxation = cast(Optional['_Relaxation'], None)
         self.__validate()
 
     def __validate(self) -> None:
@@ -517,6 +523,9 @@ class AtMostKInARow(_KInARow):
         sum(1, 7, 13)  LT 3
         sum(7, 13, 19) LT 3
     """
+    # Longer runs are the weaker requirement.
+    weaken_step = 1
+
     def apply_to_backend_request(self, block: Block, level: Tuple[Factor, Union[SimpleLevel, DerivedLevel]], backend_request: BackendRequest) -> None:
         sublistss = self._build_variable_sublistss(block, level, self.k + 1)
         # Build the requests
@@ -559,6 +568,9 @@ class AtLeastKInARow(_KInARow):
         If(And(!1, 7)) Then (13, 19)
         If(19) Then (7, 13)   --------This is a corner case
     """
+    # Shorter runs are the weaker requirement.
+    weaken_step = -1
+
     def __init__(self, k, levels):
         super().__init__(k, levels)
         self.max_trials_required = cast(int, None)
@@ -595,6 +607,59 @@ class AtLeastKInARow(_KInARow):
         return self._potential_counts_conform_individually(counts, op.ge)
 
 
+class _Relaxation:
+    """How far a constraint's `k` may be adjusted, and what it was adjusted to.
+
+    `by` is a budget in the same units as the `k` it accompanies: the value may
+    land anywhere in [k - by, k + by]. `original_k` records what the user wrote,
+    so that re-sizing a block measures the budget from there rather than from an
+    already-widened value --- `_KInARow.desugar` returns the constraint itself
+    when its level needs no replacement, so the object a repair mutates is often
+    the one the user still holds."""
+
+    def __init__(self, by: int) -> None:
+        self.by = by
+        self.original_k = cast(Optional[int], None)
+        self.applied_k = cast(Optional[int], None)
+        # What asked for the change, for the report; None until one applies.
+        self.applied_for = cast(Optional[str], None)
+
+    def base_k(self, k: int) -> int:
+        """The value the budget is measured from: what the user wrote."""
+        return self.original_k if self.original_k is not None else k
+
+    def permits(self, k: int, candidate: int) -> bool:
+        return abs(candidate - self.base_k(k)) <= self.by
+
+    def scale(self, sustain_count: int) -> None:
+        """Follow `k` when a block sustains it. A budget counts the same
+        occurrences `k` does, so whatever multiplies one multiplies the other."""
+        self.by *= sustain_count
+        if self.original_k is not None:
+            self.original_k *= sustain_count
+        if self.applied_k is not None:
+            self.applied_k *= sustain_count
+
+    def __eq__(self, other):
+        return isinstance(other, _Relaxation) and self.__dict__ == other.__dict__
+
+    def __repr__(self):
+        return "by={}".format(self.by)
+
+
+class _CapConflict(Exception):
+    """The ExactlyK caps a coverage sizing pass needs widened, each paired with
+    its relaxation and the value it must take.
+
+    Raised only for caps that `Relax` authorized, so that the caller can repair
+    and re-run the sizing; an unauthorized cap raises `ValueError` where it is
+    found instead."""
+
+    def __init__(self, deficits) -> None:
+        super().__init__("cap conflict")
+        self.deficits = deficits
+
+
 class ExactlyK(_KInARow):
     """Requires that if the given level exists at all, it must exist in a trial
     exactly ``k`` times.
@@ -627,7 +692,75 @@ class ExactlyK(_KInARow):
     def sustain_within_block(self, sustain_count: int) -> None:
         super().sustain_within_block(sustain_count)
         self.k *= sustain_count
- 
+        if self.relaxation is not None:
+            self.relaxation.scale(sustain_count)
+
+
+#: The constraints `Relax` accepts. `ExactlyK` is repaired while the block is
+#: sized; the other two are stepped only after the solver reports no solution.
+_RELAXABLE = (ExactlyK, AtMostKInARow, AtLeastKInARow)
+
+
+def Relax(constraint: Constraint, by: int) -> Constraint:
+    """Authorizes `constraint` to be weakened by up to `by`, when it would
+    otherwise leave the design with no solution. Returns a copy to use in place
+    of the original, which is left unchanged.
+
+    `by` is a budget of steps towards the weaker requirement: a larger `k` for
+    :class:`.AtMostKInARow`, a smaller one for :class:`.AtLeastKInARow`, and
+    either direction for :class:`.ExactlyK`, where neither is weaker.
+
+    Weakening is never inferred: only a constraint passed through this function
+    is eligible, and any adjustment applied is reported as the block is built or
+    as trials are synthesized, and again alongside the results. An experiment may
+    relax one constraint.
+
+    An :class:`.ExactlyK` is repaired while the block is sized, where
+    :class:`.CoverAllCombinations` can compute the value it must take. The
+    in-a-row constraints have no such model, so they are stepped only after the
+    solver reports the design unsatisfiable.
+
+    Usage::
+
+        CrossBlock(design, crossing, [CoverAllCombinations(color, word),
+                                      Relax(ExactlyK(3, (word, 'red')), by=1)])
+        CrossBlock(design, crossing, [Relax(AtMostKInARow(2, (color, 'red')), by=1)])
+    """
+    who = "Relax"
+    if not isinstance(constraint, _RELAXABLE):
+        raise ValueError((who,
+                          "only {} can be relaxed, received {}"
+                          .format(", ".join(c.__name__ for c in _RELAXABLE),
+                                  type(constraint).__name__)))
+    # bool is a subclass of int, and `by=True` is a units mistake, not a budget.
+    if not isinstance(by, int) or isinstance(by, bool):
+        raise ValueError((who, "by must be an integer, received {}".format(by)))
+    if by <= 0:
+        raise ValueError((who, "by must be greater than 0"))
+    # A copy, so that a constraint the caller holds is not altered by wrapping
+    # it. Shallow: a deep copy would clone the level, and with it the factor,
+    # leaving the constraint pointing at a factor the design does not contain.
+    relaxed = copy(constraint)
+    relaxed.relaxation = _Relaxation(by)
+    return relaxed
+
+
+def solver_relaxable(block):
+    """The block's `Relax`-authorized constraint that the solver loop can step,
+    or None. An `ExactlyK` has no step: coverage sizing already repaired it, so
+    it never reaches the loop."""
+    for c in block.constraints:
+        if isinstance(c, _KInARow) and c.relaxation is not None and c.weaken_step:
+            return c
+    return None
+
+
+def relax_budget(constraint) -> int:
+    """Steps the loop may take. `k` must stay positive, so lowering it stops at
+    1 however large the authorized budget is."""
+    by = constraint.relaxation.by
+    return by if constraint.weaken_step > 0 else min(by, constraint.k - 1)
+
 
 class ExactlyKInARow(_KInARow):
     """Requires that if the given level exists at all, it must exist in a
@@ -1468,19 +1601,29 @@ class CoverAllCombinations(Constraint):
                 seqs.append(ct)
         return (pins, caps, seqs)
 
+    @staticmethod
+    def _cap_demand(ct, k, R_free, forced, forced_weights) -> int:
+        """The occurrences an ExactlyK's level is driven to at `k` instances:
+        each forced combination at its per-instance weight, plus one for each
+        free combination that contains the level.
+
+        Only the forced term grows with `k`, so `k` = 1 gives the floor across
+        every instance count, and a larger `k` always demands at least as much."""
+        fname, lname = ct.level.factor.name, ct.level.name
+        forced_l = sum(forced_weights.get(c, 1) for c in forced if (fname, lname) in c)
+        free_l = sum(1 for c in R_free if (fname, lname) in c)
+        return k * forced_l + free_l
+
     def _feasible_at(self, k, instance_len, R_free, forced, slots, pins, caps,
                      seq_free, sizing_block, slot_weights=None, forced_weights={}):
         """Whether coverage is achievable with `k` instances, once the statically
         modeled constraint effects are folded in jointly."""
-        # ExactlyK caps: the capped level's minimum occurrences at k instances are
-        # k * (forced occurrences per instance) + (one per required free combo).
-        # The forced term grows with k, so feasibility is NOT monotone in k —
+        # A cap's demand grows with k, so feasibility is NOT monotone in k —
         # which is why the caller scans k linearly instead of binary-searching.
+        # `caps` carries only the binding caps; ones that `Relax` authorized are
+        # reconciled by the caller against the K the scan settles on.
         for ct in caps:
-            fname, lname = ct.level.factor.name, ct.level.name
-            forced_l = sum(forced_weights.get(c, 1) for c in forced if (fname, lname) in c)
-            free_l = sum(1 for c in R_free if (fname, lname) in c)
-            if k * forced_l + free_l > ct.k:
+            if self._cap_demand(ct, k, R_free, forced, forced_weights) > ct.k:
                 return False
         if seq_free:
             return self._positional_feasible(k, instance_len, R_free, seq_free,
@@ -1585,20 +1728,25 @@ class CoverAllCombinations(Constraint):
         already are."""
         (R, forced, R_free, slots, _, slot_weights, forced_weights) = \
             self._coverage_analysis(analysis, group, exclusion_block=block)
-        # Definitive check: `required` = the capped level's occurrences at K=1
-        # (each free combo at least once + each forced combo at its per-instance
-        # weight). Adding instances only increases the forced term, so a cap
-        # below this can never be reconciled at any K.
+        binding = []
+        relaxable = []
         for ct in caps:
-            fname, lname = ct.level.factor.name, ct.level.name
-            required = (sum(1 for c in R_free if (fname, lname) in c)
-                        + sum(forced_weights.get(c, 1) for c in forced
-                              if (fname, lname) in c))
+            rl = ct.relaxation
+            if rl is None:
+                binding.append(ct)
+            else:
+                relaxable.append((ct, rl))
+        # Definitive check: a cap below the K=1 demand (see _cap_demand) can be
+        # reconciled at no instance count at all, so it fails here rather than
+        # after a scan that cannot succeed.
+        for ct in binding:
+            required = self._cap_demand(ct, 1, R_free, forced, forced_weights)
             if required > ct.k:
                 raise ValueError((who,
                                   "covering all combinations requires at least {} trials "
                                   "with '{} {}' but an ExactlyK constraint allows exactly "
-                                  "{}".format(required, fname, lname, ct.k)))
+                                  "{}".format(required, ct.level.factor.name,
+                                              ct.level.name, ct.k)))
         k_opt = self._min_instances(R_free, slots, slot_weights)
         # Scan ceiling: |R_free| instances provably suffice for the plain model
         # (see _min_instances), so twice that (or twice k_opt) leaves headroom
@@ -1606,14 +1754,85 @@ class CoverAllCombinations(Constraint):
         cap = max(len(R), k_opt) * 2
         k = k_opt
         while k <= cap:
-            if self._feasible_at(k, instance_len, R_free, forced, slots, pins, caps,
+            if self._feasible_at(k, instance_len, R_free, forced, slots, pins, binding,
                                  seq_free, block, slot_weights, forced_weights):
+                # The scan rises from the floor, so this is the smallest feasible
+                # K, and since demand grows with K it is also the K that asks the
+                # least of the relaxable caps.
+                deficits = []
+                for (ct, rl) in relaxable:
+                    demand = self._cap_demand(ct, k, R_free, forced, forced_weights)
+                    # Demand under the cap is no conflict: the model counts a
+                    # minimum, and the solver can reach the equality using the
+                    # occurrences the crossing leaves free.
+                    if demand > ct.k:
+                        deficits.append((ct, rl, demand))
+                if deficits:
+                    raise _CapConflict(deficits)
                 return k
             k += 1
         conflicting = [repr(ct) for ct in (pins + caps + seq_free)]
         raise ValueError((who,
                           "no trial count up to {} instances reconciles coverage with "
                           "the other constraints ({})".format(cap, ", ".join(conflicting))))
+
+    def reconcile_trials(self, block) -> int:
+        """`autosize_trials`, plus the widening that `Relax` authorizes.
+
+        `autosize_trials` stays a pure computation so that this can re-run it
+        after each repair: a widened cap changes the coverage model, so sizing
+        is recomputed rather than patched.
+
+        Every pass either returns or raises some cap by at least one, and every
+        budget is finite, so the authorized slack bounds the number of passes."""
+        who = "CoverAllCombinations"
+        for _ in range(self._relaxation_budget(block) + 1):
+            try:
+                total = self.autosize_trials(block)
+            except _CapConflict as conflict:
+                for (ct, rl, needed) in conflict.deficits:
+                    if not rl.permits(ct.k, needed):
+                        raise ValueError((who,
+                                          "covering all combinations requires {} trials "
+                                          "with '{} {}', but the ExactlyK constraint allows "
+                                          "{} and Relax authorizes a change of only {}"
+                                          .format(needed, ct.level.factor.name,
+                                                  ct.level.name, rl.base_k(ct.k), rl.by)))
+                    if rl.original_k is None:
+                        rl.original_k = ct.k
+                    rl.applied_k = needed
+                    rl.applied_for = repr(self)
+                    ct.k = needed
+                continue
+            self._record_relaxations(block)
+            return total
+        raise ValueError((who,
+                          "coverage sizing did not settle after applying every "
+                          "authorized relaxation"))
+
+    @staticmethod
+    def _relaxation_budget(block) -> int:
+        """Total slack `Relax` authorized across the block's ExactlyK caps."""
+        total = 0
+        for ct in block.constraints:
+            if isinstance(ct, ExactlyK) and ct.relaxation is not None:
+                total += ct.relaxation.by
+        return total
+
+    @staticmethod
+    def _record_relaxations(block) -> None:
+        """Restate the block's applied relaxations from the caps themselves, so
+        that a cap widened over several passes is reported at its final value
+        once rather than at each step."""
+        messages = []
+        for ct in block.constraints:
+            rl = ct.relaxation if isinstance(ct, ExactlyK) else None
+            if rl is not None and rl.applied_k is not None:
+                messages.append(
+                    "ExactlyK for '{} {}' relaxed from {} to {}, as {} requires."
+                    .format(ct.level.factor.name, ct.level.name,
+                            rl.original_k, rl.applied_k, rl.applied_for))
+        block.applied_relaxations = messages
 
     def sizing_message(self, total) -> str:
         """The line a block reports as it grows itself for coverage."""

--- a/sweetpea/_internal/constraint.py
+++ b/sweetpea/_internal/constraint.py
@@ -413,6 +413,9 @@ class _KInARow(Constraint):
         if self.within_block is None:
             self.within_block = within_block
 
+    def set_within_block(self, within_block: BlockGeometry) -> None:
+        self.within_block = within_block
+
     def sustain_within_block(self, sustain_count: int) -> None:
         self.within_block = self.within_block.sustain(sustain_count)
  
@@ -745,6 +748,30 @@ def Relax(constraint: Constraint, by: int) -> Constraint:
     return relaxed
 
 
+def record_concessions(block) -> None:
+    """Restate every concession from the block's own state.
+
+    Derived rather than accumulated, so that a constraint changed over several
+    passes is reported at its final value, and so that no kind of concession
+    overwrites another's entries."""
+    messages = []
+    for ct in block.constraints:
+        if isinstance(ct, _KInARow) and ct.relaxation is not None \
+                and ct.relaxation.applied_k is not None:
+            rl = ct.relaxation
+            messages.append(
+                "{} for '{} {}' relaxed from {} to {}, as {}."
+                .format(type(ct).__name__, ct.level.factor.name, ct.level.name,
+                        rl.original_k, rl.applied_k, rl.applied_for))
+        elif isinstance(ct, CoverAllCombinations) and ct.dropped:
+            given_up = ct.optional[len(ct.optional) - ct.dropped:]
+            messages.append(
+                "Coverage gave up {}: each of their levels appears at least "
+                "once, as the solver found no solution otherwise."
+                .format(", ".join(str(f.name) for f in given_up)))
+    block.applied_relaxations = messages
+
+
 def solver_relaxable(block):
     """The block's `Relax`-authorized constraint that the solver loop can step,
     or None. An `ExactlyK` has no step: coverage sizing already repaired it, so
@@ -996,6 +1023,9 @@ class Pin(Constraint):
     def init_within_block(self, within_block: BlockGeometry) -> None:
         if self.within_block is None:
             self.within_block = within_block
+
+    def set_within_block(self, within_block: BlockGeometry) -> None:
+        self.within_block = within_block
 
     def sustain_within_block(self, sustain_count: int) -> None:
         if self.within_block:
@@ -1449,16 +1479,34 @@ class CoverAllCombinations(Constraint):
         self.factors = self.required + self.optional
         if self.factors == []:
             raise ValueError(who, "factor list must be non-empty")
-        # Coverage requirements, one fully-crossed combination set per group:
-        # the required factors together, then each optional factor on its own so
-        # that only its individual levels have to appear.
-        self.groups = cast(List[List[Factor]],
-                           ([required] if required else [])
-                           + [[f] for f in self.optional])
+        # How many optional factors have been given up so far.
+        self.dropped = 0
+        self.groups = self._grouping_after(0)
         # Set by Nest during construction: the inner block whose crossing determines
         # which listed factors are pinned vs. free. None for other block types, in
         # which case the attached block itself is analyzed.
         self._inner_block = cast(Optional[MultiCrossBlockRepeat], None)
+
+    def _grouping_after(self, dropped: int) -> List[List[Factor]]:
+        """Coverage requirements once `dropped` optional factors have been given
+        up, last in the list first.
+
+        A factor still kept is crossed with the others, so their combinations
+        must all appear. A factor given up forms a group of its own, which asks
+        only that each of its own levels appears somewhere."""
+        keep_count = len(self.optional) - dropped
+        kept = self.required + self.optional[:keep_count]
+        return (cast(List[List[Factor]], [kept] if kept else [])
+                + [[f] for f in self.optional[keep_count:]])
+
+    def drop_one(self) -> Factor:
+        """Give up the last optional factor still kept, and report it."""
+        self.dropped += 1
+        self.groups = self._grouping_after(self.dropped)
+        return self.optional[len(self.optional) - self.dropped]
+
+    def can_drop(self) -> bool:
+        return self.dropped < len(self.optional)
 
     # ~~~~~~~~~~~~~~ Coverage analysis (the "K" computation) ~~~~~~~~~~~~~~
 
@@ -1801,7 +1849,7 @@ class CoverAllCombinations(Constraint):
                     if rl.original_k is None:
                         rl.original_k = ct.k
                     rl.applied_k = needed
-                    rl.applied_for = repr(self)
+                    rl.applied_for = "{} requires".format(repr(self))
                     ct.k = needed
                 continue
             self._record_relaxations(block)
@@ -1821,26 +1869,31 @@ class CoverAllCombinations(Constraint):
 
     @staticmethod
     def _record_relaxations(block) -> None:
-        """Restate the block's applied relaxations from the caps themselves, so
-        that a cap widened over several passes is reported at its final value
-        once rather than at each step."""
-        messages = []
-        for ct in block.constraints:
-            rl = ct.relaxation if isinstance(ct, ExactlyK) else None
-            if rl is not None and rl.applied_k is not None:
-                messages.append(
-                    "ExactlyK for '{} {}' relaxed from {} to {}, as {} requires."
-                    .format(ct.level.factor.name, ct.level.name,
-                            rl.original_k, rl.applied_k, rl.applied_for))
-        block.applied_relaxations = messages
+        record_concessions(block)
 
     def sizing_message(self, total) -> str:
-        """The line a block reports as it grows itself for coverage."""
+        """The line a block reports as it sizes itself for coverage. Named
+        factors are the ones already given up, so nothing is listed until a drop
+        has happened."""
         msg = "{} requires {} trials.".format(repr(self), total)
-        if self.optional:
+        given_up = self.optional[len(self.optional) - self.dropped:] if self.dropped else []
+        if given_up:
             msg += " ({}: each level appears at least once)".format(
-                ", ".join(str(f.name) for f in self.optional))
+                ", ".join(str(f.name) for f in given_up))
         return msg
+
+    def optional_hint(self) -> Optional[str]:
+        """What could still be moved to `optional`, or None when there is
+        nothing worth suggesting: with one factor, giving it up leaves coverage
+        asking almost nothing.
+
+        Worded as a condition because a factor in `optional` is given up only
+        when the design has no solution, so this cannot promise fewer trials."""
+        if not self.required or len(self.factors) < 2:
+            return None
+        return ("Any of {} can be moved to `optional`, to be given up for a "
+                "shorter experiment if no solution is found."
+                .format(", ".join(str(f.name) for f in self.required)))
 
     @staticmethod
     def _k_lower_bound(R_free, slots, slot_weights=None):
@@ -1934,6 +1987,8 @@ class CoverAllCombinations(Constraint):
         c = CoverAllCombinations(*replace(self.required),
                                  optional=replace(self.optional))
         c._inner_block = self._inner_block
+        c.dropped = self.dropped
+        c.groups = c._grouping_after(c.dropped)
         return [c]
 
     def validate(self, block: Block) -> None:

--- a/sweetpea/_internal/core/__init__.py
+++ b/sweetpea/_internal/core/__init__.py
@@ -62,7 +62,7 @@ Classes
 
 from .cnf import Clause, CNF, Var
 from .generate import (
-    AssertionType, GenerationRequest, Solution,
+    AssertionType, GenerationRequest, Solution, SolveOutcome,
     cnf_is_satisfiable, sample_non_uniform, sample_non_uniform_from_specification, sample_uniform,
     combine_cnf_with_requests
 )

--- a/sweetpea/_internal/core/generate/__init__.py
+++ b/sweetpea/_internal/core/generate/__init__.py
@@ -12,4 +12,4 @@ SweetPea offers three mechanisms for CNF interaction:
 from .is_satisfiable import cnf_is_satisfiable
 from .sample_non_uniform import sample_non_uniform, sample_non_uniform_from_specification
 from .sample_uniform import sample_uniform
-from .utility import AssertionType, GenerationRequest, SampleType, ProblemSpecification, Solution, combine_cnf_with_requests
+from .utility import AssertionType, GenerationRequest, SampleType, ProblemSpecification, Solution, SolveOutcome, combine_cnf_with_requests

--- a/sweetpea/_internal/core/generate/sample_non_uniform.py
+++ b/sweetpea/_internal/core/generate/sample_non_uniform.py
@@ -14,11 +14,12 @@
 
 
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from ..cnf import CNF
 from .tools.cryptominisat import DEFAULT_DOCKER_MODE_ON, cryptominisat_solve
-from .utility import GenerationRequest, ProblemSpecification, Solution, combine_and_save_cnf, temporary_cnf_file
+from .utility import (GenerationRequest, ProblemSpecification, Solution, SolveOutcome,
+                      combine_and_save_cnf, temporary_cnf_file)
 
 
 __all__ = ['sample_non_uniform', 'sample_non_uniform_from_specification']
@@ -29,15 +30,16 @@ def sample_non_uniform(count: int,
                        fresh: int,
                        support: int,
                        generation_requests: List[GenerationRequest]
-                       ) -> List[Solution]:
+                       ) -> Tuple[List[Solution], SolveOutcome]:
     """Samples solutions to a CNF problem non-uniformly. Produces ``count``
-    solutions, each with a support set of length ``support``.
+    solutions, each with a support set of length ``support``, and the outcome
+    that explains how many were produced.
     """
     with temporary_cnf_file() as cnf_file:
         combine_and_save_cnf(cnf_file, initial_cnf, fresh, support, generation_requests)
         print("Running CryptoMiniSat...")
-        solutions = compute_solutions(cnf_file, support, count)
-        return [Solution(solution, 1) for solution in solutions]
+        (solutions, outcome) = compute_solutions(cnf_file, support, count)
+        return ([Solution(solution, 1) for solution in solutions], outcome)
 
 
 def sample_non_uniform_from_specification(spec: ProblemSpecification) -> List[Solution]:
@@ -50,7 +52,7 @@ def sample_non_uniform_from_specification(spec: ProblemSpecification) -> List[So
         SweetPea's input was given as JSON files. This should no longer be
         necessary.
     """
-    return sample_non_uniform(spec.sample_count, spec.cnf, spec.fresh, spec.support, spec.requests)
+    return sample_non_uniform(spec.sample_count, spec.cnf, spec.fresh, spec.support, spec.requests)[0]
 
 
 def compute_solutions(filename: Path,
@@ -58,26 +60,29 @@ def compute_solutions(filename: Path,
                       count: int,
                       solutions: Optional[List[List[int]]] = None,
                       use_docker: bool = DEFAULT_DOCKER_MODE_ON
-                      ) -> List[List[int]]:
+                      ) -> Tuple[List[List[int]], SolveOutcome]:
     """Attempts to solve a CNF problem ``count`` times with CryptoMiniSAT. Each
     time a solution is generated, it is added to the problem file's header so
     new solutions may be generated. If at any point CryptoMiniSAT fails to
     generate a solution, execution terminates and the existing list of
-    solutions will be returned.
+    solutions is returned, along with the outcome that explains the stop.
     """
-    # TODO: Implement iteratively instead of recursively.
-    while True:
-        if solutions is None:
-            solutions = []
-        if count == 0:
-            return solutions
+    if solutions is None:
+        solutions = []
+    while count > 0:
         solution = cryptominisat_solve(filename, use_docker)
+        if solution is None:
+            return (solutions, SolveOutcome.UNKNOWN)
         if not solution:
-            return solutions
+            # No solution on the first solve means the formula has none; after
+            # one has been found it means the distinct solutions ran out.
+            return (solutions,
+                    SolveOutcome.SATISFIED if solutions else SolveOutcome.UNSATISFIABLE)
         solution = solution[:support]
         update_file(filename, solution)
         count -= 1
         solutions += [solution]
+    return (solutions, SolveOutcome.SATISFIED)
 
 
 def update_file(filename: Path, solution: List[int]):

--- a/sweetpea/_internal/core/generate/utility.py
+++ b/sweetpea/_internal/core/generate/utility.py
@@ -17,6 +17,7 @@ from ..cnf import CNF, Var
 
 __all__ = [
     'AssertionType', 'GenerationRequest', 'SampleType', 'ProblemSpecification', 'Solution',
+    'SolveOutcome',
     'combine_and_save_cnf', 'combine_cnf_with_requests', 'save_cnf', 'temporary_cnf_file'
 ]
 
@@ -36,6 +37,16 @@ def temporary_cnf_file(base_path: Path = Path('.'), suffix: str = ".cnf") -> Ite
     finally:
         if cnf_file.exists():
             cnf_file.unlink()
+
+
+class SolveOutcome(Enum):
+    """Why a solver run produced the samples it did."""
+    #: At least one solution was found.
+    SATISFIED = auto()
+    #: The formula has no solution.
+    UNSATISFIABLE = auto()
+    #: The solver reported neither, e.g. it crashed or timed out.
+    UNKNOWN = auto()
 
 
 class AssertionType(Enum):

--- a/sweetpea/_internal/cross_block.py
+++ b/sweetpea/_internal/cross_block.py
@@ -124,59 +124,16 @@ class MultiCrossBlockRepeat(Block):
         if not all([s == self.preamble_sizes[0] for s in self.preamble_sizes]) and self.alignment == AlignmentMode.EQUAL_PREAMBLE:
             raise RuntimeError("AlignmentMode.EQUAL_PREAMBLE not allowed with different preamble sizes")
 
-        # Auto-size for CoverAllCombinations: raise the trial count to the minimum
-        # needed for coverage. Must run before trials_per_sample() is first cached.
-        for ct in self.constraints:
-            if isinstance(ct, CoverAllCombinations):
-                reported = len(self.applied_relaxations)
-                target = ct.reconcile_trials(self)
-                for message in self.applied_relaxations[reported:]:
-                    # Ahead of the trial count: the widening is what makes that
-                    # count reachable.
-                    print(message)
-                if target > 0:
-                    # Report what coverage costs, rather than the block's final
-                    # length: MinimumTrials and sustain rounding can lengthen it
-                    # further, which is not coverage's doing. A zero target means
-                    # coverage was not statically modeled, so there is no count.
-                    print(ct.sizing_message(target))
-                if target > self.min_trials:
-                    self.min_trials = target
-                    for count in self.crossing_sustain_counts:
-                        # keep min_trials a multiple of each sustain count
-                        if (self.min_trials // count) * count != self.min_trials:
-                            self.min_trials = ((self.min_trials // count) + 1) * count
-                    # A constraint's validate() (e.g. Pin's range check) may have
-                    # already cached the pre-growth trial count; invalidate it.
-                    self._trials_per_sample = None
+        # Kept so that a later resize can repeat the size-dependent work.
+        self._mode = mode
+        self._who = who
+        # The count before coverage sizing: a resize shrinks back towards this,
+        # never below what MinimumTrials or sustain rounding already require.
+        self._base_min_trials = self.min_trials
+        self._geometry_owned = cast(Optional[List[Constraint]], None)
 
-        if mode != RepeatMode.REPEAT:
-            num_trials = self.trials_per_sample()
-            for i in range(0, len(crossings)):
-                w = ((num_trials // crossing_sustain_counts[i]) - self.preamble_sizes[i] + self.crossing_sizes[i] - 1) // self.crossing_sizes[i]
-                if w != self.crossing_weights[i]:
-                    if mode == RepeatMode.EQUAL:
-                        raise RuntimeError("RepeatMode.EQUAL not allowed with different crossing+preamble sizes")
-                    self.crossing_weights[i] = w;
-
-        self._alignment_preamble = max(
-            (
-                f.first_level.window.start or 0
-                for f in self.design
-                if isinstance(f, DerivedFactor)
-                and f.has_complex_window
-            ),
-            default=0
-        )
-
-        within_block = self.get_geometry(0)
-        for ct in self.constraints:
-            ct.init_within_block(within_block)
-        # in case this block is later combined, also update constraints in `orig_constraints`
-        for ct in self.orig_constraints:
-            ct.init_within_block(within_block)
-
-        self.__validate(who)
+        self._size_for_coverage(hint=True)
+        self._apply_trial_count()
 
         # knowing that factors can be derived (and how) is useful for `RandomGen`
         derivable_factors = {}
@@ -191,6 +148,84 @@ class MultiCrossBlockRepeat(Block):
             if f in derivable_factors:
                 derivable_factors.pop(f)
         self.derivable_factors = derivable_factors
+
+    def _size_for_coverage(self, hint: bool) -> None:
+        """Size the block to what CoverAllCombinations requires, and report the
+        count.
+
+        Starts from the pre-coverage count rather than from whatever a previous
+        pass produced, so that giving a factor up can make the block shorter."""
+        from sweetpea._internal.constraint import CoverAllCombinations
+        self.min_trials = self._base_min_trials
+        self._trials_per_sample = None
+        for ct in self.constraints:
+            if isinstance(ct, CoverAllCombinations):
+                reported = len(self.applied_relaxations)
+                target = ct.reconcile_trials(self)
+                for message in self.applied_relaxations[reported:]:
+                    # Ahead of the trial count: the widening is what makes that
+                    # count reachable.
+                    print(message)
+                if target > 0:
+                    # Report what coverage costs, rather than the block's final
+                    # length: MinimumTrials and sustain rounding can lengthen it
+                    # further, which is not coverage's doing. A zero target means
+                    # coverage was not statically modeled, so there is no count.
+                    print(ct.sizing_message(target))
+                    if hint:
+                        advice = ct.optional_hint()
+                        if advice:
+                            print(advice)
+                if target > self.min_trials:
+                    self.min_trials = target
+                    for count in self.crossing_sustain_counts:
+                        # keep min_trials a multiple of each sustain count
+                        if (self.min_trials // count) * count != self.min_trials:
+                            self.min_trials = ((self.min_trials // count) + 1) * count
+                    # A constraint's validate() (e.g. Pin's range check) may have
+                    # already cached the pre-growth trial count; invalidate it.
+                    self._trials_per_sample = None
+
+    def _apply_trial_count(self) -> None:
+        """The part of construction that depends on how many trials the block
+        has. Repeated after a resize, since every piece of it is derived from
+        that count."""
+        if self._mode != RepeatMode.REPEAT:
+            num_trials = self.trials_per_sample()
+            for i in range(0, len(self.crossings)):
+                w = ((num_trials // self.crossing_sustain_counts[i]) - self.preamble_sizes[i]
+                     + self.crossing_sizes[i] - 1) // self.crossing_sizes[i]
+                if w != self.crossing_weights[i]:
+                    if self._mode == RepeatMode.EQUAL:
+                        raise RuntimeError("RepeatMode.EQUAL not allowed with different crossing+preamble sizes")
+                    self.crossing_weights[i] = w
+
+        self._alignment_preamble = max(
+            (
+                f.first_level.window.start or 0
+                for f in self.design
+                if isinstance(f, DerivedFactor)
+                and f.has_complex_window
+            ),
+            default=0
+        )
+
+        if self._geometry_owned is None:
+            # A constraint that already carries a geometry got it from an inner
+            # block, which this block does not resize; it keeps that one.
+            self._geometry_owned = [ct for ct in self.constraints + self.orig_constraints
+                                    if getattr(ct, 'within_block', None) is None]
+        within_block = self.get_geometry(0)
+        for ct in self._geometry_owned:
+            ct.set_within_block(within_block)
+
+        self.__validate(self._who)
+
+    def resize_for_coverage(self) -> None:
+        """Re-size after a coverage constraint gives a factor up. The advice on
+        what else could be given up belongs to the first report only."""
+        self._size_for_coverage(hint=False)
+        self._apply_trial_count()
 
     def __validate(self, who: str):
         self.__validate_crossing(who)

--- a/sweetpea/_internal/cross_block.py
+++ b/sweetpea/_internal/cross_block.py
@@ -119,7 +119,13 @@ class MultiCrossBlockRepeat(Block):
         # needed for coverage. Must run before trials_per_sample() is first cached.
         for ct in self.constraints:
             if isinstance(ct, CoverAllCombinations):
-                target = ct.negotiate_trials(self)
+                target = ct.autosize_trials(self)
+                if target > 0:
+                    # Report what coverage costs, rather than the block's final
+                    # length: MinimumTrials and sustain rounding can lengthen it
+                    # further, which is not coverage's doing. A zero target means
+                    # coverage was not statically modeled, so there is no count.
+                    print(ct.sizing_message(target))
                 if target > self.min_trials:
                     self.min_trials = target
                     for count in self.crossing_sustain_counts:

--- a/sweetpea/_internal/cross_block.py
+++ b/sweetpea/_internal/cross_block.py
@@ -91,11 +91,20 @@ class MultiCrossBlockRepeat(Block):
 
         crossings = [c for c in crossings if len(c) > 0]
 
-        from sweetpea._internal.constraint import Cross, Consistency, Sustain, CoverAllCombinations
+        from sweetpea._internal.constraint import (Cross, Consistency, Sustain,
+                                                   CoverAllCombinations, _KInARow)
         from sweetpea._internal.derivation_processor import DerivationProcessor
         self.orig_design = design
         self.orig_crossings = crossings
         self.orig_constraints = constraints
+        # Counted before desugaring, so a whole-factor Relax stays the one
+        # constraint the user wrote rather than one per level.
+        relaxed = [c for c in constraints
+                   if isinstance(c, _KInARow) and c.relaxation is not None]
+        if len(relaxed) > 1:
+            raise ValueError((who,
+                              "an experiment may relax one constraint, but {} were "
+                              "given to Relax".format(len(relaxed))))
         design, crossings, replacements = _desugar_factors_with_weights(design, crossings)
         all_constraints = cast(List[Constraint], [Cross(), Consistency()]) + constraints
         if any(count != 1 for count in crossing_sustain_counts):
@@ -119,7 +128,12 @@ class MultiCrossBlockRepeat(Block):
         # needed for coverage. Must run before trials_per_sample() is first cached.
         for ct in self.constraints:
             if isinstance(ct, CoverAllCombinations):
-                target = ct.autosize_trials(self)
+                reported = len(self.applied_relaxations)
+                target = ct.reconcile_trials(self)
+                for message in self.applied_relaxations[reported:]:
+                    # Ahead of the trial count: the widening is what makes that
+                    # count reachable.
+                    print(message)
                 if target > 0:
                     # Report what coverage costs, rather than the block's final
                     # length: MinimumTrials and sustain rounding can lengthen it

--- a/sweetpea/_internal/cross_block.py
+++ b/sweetpea/_internal/cross_block.py
@@ -119,7 +119,7 @@ class MultiCrossBlockRepeat(Block):
         # needed for coverage. Must run before trials_per_sample() is first cached.
         for ct in self.constraints:
             if isinstance(ct, CoverAllCombinations):
-                target = ct.autosize_trials(self)
+                target = ct.negotiate_trials(self)
                 if target > self.min_trials:
                     self.min_trials = target
                     for count in self.crossing_sustain_counts:

--- a/sweetpea/_internal/main.py
+++ b/sweetpea/_internal/main.py
@@ -58,7 +58,7 @@ from sweetpea._internal.constraint import (
     LatinSquare,
     Sequential,
     CoverAllCombinations,
-    solver_relaxable, relax_budget
+    solver_relaxable, relax_budget, record_concessions
 )
 from sweetpea._internal.core import SolveOutcome
 from sweetpea._internal.sampling_strategy.base import Gen
@@ -410,7 +410,7 @@ def synthesize_trials(block: Block,
         starting(sampling_strategy.class_name())
     else:
         starting(sampling_strategy)
-    sampling_result = _weaken_until_satisfiable(block, run(), run)
+    sampling_result = _concede_until_satisfiable(block, run(), run)
 
     # DW: I am not sure if I need to fix this. Need to discuss with Matthew
     raw_samples = sampling_result.samples[:samples]
@@ -443,6 +443,44 @@ def synthesize_trials(block: Block,
     return trialss
 
 
+def _concede_until_satisfiable(block, result, run):
+    """The concessions the design authorized, in order: every step of a Relax
+    budget, then one coverage factor at a time.
+
+    Applied cumulatively and never taken back, so the sequence is linear in the
+    number of concessions rather than a search over their combinations."""
+    result = _weaken_until_satisfiable(block, result, run)
+    return _drop_optional_until_satisfiable(block, result, run)
+
+
+def _drop_optional_until_satisfiable(block, result, run):
+    """Give up one optional coverage factor at a time, last in the list first,
+    resizing the block after each.
+
+    A drop is kept whether or not it helps, so what is reported is what the
+    block actually requires by the end."""
+    coverage = _droppable_coverage(block)
+    if result.outcome is not SolveOutcome.UNSATISFIABLE or coverage is None:
+        return result
+    while coverage.can_drop():
+        given_up = coverage.drop_one()
+        print("No solution; giving up {}.".format(given_up.name))
+        # The resize records the concession, from the constraint's own state.
+        block.resize_for_coverage()
+        result = run()
+        if result.samples:
+            return result
+    return result
+
+
+def _droppable_coverage(block):
+    """The block's coverage constraint that still has a factor to give up."""
+    for ct in block.constraints:
+        if isinstance(ct, CoverAllCombinations) and ct.can_drop():
+            return ct
+    return None
+
+
 def _weaken_until_satisfiable(block, result, run):
     """Step the block's one `Relax`-authorized constraint until the design has a
     solution or its budget runs out, re-solving after each step.
@@ -454,21 +492,23 @@ def _weaken_until_satisfiable(block, result, run):
         return result
     relaxation = constraint.relaxation
     written = relaxation.base_k(constraint.k)
+    relaxation.original_k = written
+    relaxation.applied_for = "the solver found no solution otherwise"
     for _ in range(relax_budget(constraint)):
         constraint.k += constraint.weaken_step
+        # Track the value as it moves, not only when this loop is the one that
+        # succeeds: a later concession can be what completes the design, and the
+        # report has to name every constraint the design ended up relying on.
+        relaxation.applied_k = constraint.k
         print("No solution; retrying with {}(k={}).".format(
             type(constraint).__name__, constraint.k))
         result = run()
         if result.samples:
-            relaxation.original_k = written
-            relaxation.applied_k = constraint.k
-            block.applied_relaxations.append(
-                "{} for '{} {}' relaxed from {} to {}, as the solver found no "
-                "solution otherwise.".format(
-                    type(constraint).__name__, constraint.level.factor.name,
-                    constraint.level.name, written, constraint.k))
+            record_concessions(block)
             return result
-    constraint.k = written
+    # The steps stay: concessions accumulate so that a later one starts from
+    # what the earlier ones bought. Nothing is written to the block's report
+    # here, so a run that never produces a design reports nothing.
     return result
 
 

--- a/sweetpea/_internal/main.py
+++ b/sweetpea/_internal/main.py
@@ -18,6 +18,7 @@ __all__ = [
 
     'Constraint', 
     'Exclude', 'Pin', 'MinimumTrials', 'ExactlyK',
+    'Relax',
     'AtMostKInARow', 'AtLeastKInARow',
     'ExactlyKInARow',
     'LatinSquare',
@@ -53,10 +54,13 @@ from sweetpea._internal.constraint import (
     Consistency, Constraint, Derivation,
     Exclude, Pin, MinimumTrials,
     ExactlyK, AtMostKInARow, AtLeastKInARow, ExactlyKInARow,
+    Relax,
     LatinSquare,
     Sequential,
-    CoverAllCombinations
+    CoverAllCombinations,
+    solver_relaxable, relax_budget
 )
+from sweetpea._internal.core import SolveOutcome
 from sweetpea._internal.sampling_strategy.base import Gen
 from sweetpea._internal.sampling_strategy.uniform import UniformGen
 from sweetpea._internal.sampling_strategy.iterate import IterateGen
@@ -179,6 +183,8 @@ def print_experiments(block, experiments):
             ls_name = ct.name
             ls_dlen = ct.diagonal_length()
 
+    for message in block.applied_relaxations:
+        print(message)
     print('\n{} trial sequences found.\n'.format(len(experiments)))
     for idx, e in enumerate(experiments):
         print('Experiment {}:'.format(idx))
@@ -394,13 +400,17 @@ def synthesize_trials(block: Block,
         # type: (Any) -> None
         print("Sampling {} trial sequences using {}.".format(samples, who))
 
+    def run():
+        if isinstance(sampling_strategy, type):
+            return sampling_strategy.sample(block, samples)
+        return sampling_strategy.sample_object(block, samples)
+
     if isinstance(sampling_strategy, type):
         assert issubclass(sampling_strategy, Gen)
         starting(sampling_strategy.class_name())
-        sampling_result = sampling_strategy.sample(block, samples)
     else:
         starting(sampling_strategy)
-        sampling_result = sampling_strategy.sample_object(block, samples)
+    sampling_result = _weaken_until_satisfiable(block, run(), run)
 
     # DW: I am not sure if I need to fix this. Need to discuss with Matthew
     raw_samples = sampling_result.samples[:samples]
@@ -428,23 +438,66 @@ def synthesize_trials(block: Block,
         # Restore ContinuousFactor to the design
 
     if not trialss:
-        # With a coverage constraint, an empty result means the solver found the
-        # joint constraints unsatisfiable. Point at the constraints that coverage
-        # auto-sizing cannot account for (ordering constraints and LatinSquare).
-        from sweetpea._internal.constraint import _KInARow
-        cacs = [ct for ct in block.orig_constraints if isinstance(ct, CoverAllCombinations)]
-        if cacs:
-            msg = ("No trial sequences found: the constraints could not be satisfied "
-                   "together with " + " and ".join(repr(ct) for ct in cacs) + ".")
-            unmodeled = sorted(set(type(ct).__name__ for ct in block.orig_constraints
-                                   if isinstance(ct, (_KInARow, LatinSquare))))
-            if unmodeled:
-                msg += (" Constraints of kind " + ", ".join(unmodeled)
-                        + " are not folded into coverage auto-sizing; a MinimumTrials"
-                          " constraint can provide additional trials.")
-            print(msg)
+        print(_no_sequences_message(block, sampling_result.outcome))
 
     return trialss
+
+
+def _weaken_until_satisfiable(block, result, run):
+    """Step the block's one `Relax`-authorized constraint until the design has a
+    solution or its budget runs out, re-solving after each step.
+
+    Only a definitive UNSATISFIABLE justifies this. An unknown outcome means the
+    solver failed, which is no reason to alter the experiment."""
+    constraint = solver_relaxable(block)
+    if result.outcome is not SolveOutcome.UNSATISFIABLE or constraint is None:
+        return result
+    relaxation = constraint.relaxation
+    written = relaxation.base_k(constraint.k)
+    for _ in range(relax_budget(constraint)):
+        constraint.k += constraint.weaken_step
+        print("No solution; retrying with {}(k={}).".format(
+            type(constraint).__name__, constraint.k))
+        result = run()
+        if result.samples:
+            relaxation.original_k = written
+            relaxation.applied_k = constraint.k
+            block.applied_relaxations.append(
+                "{} for '{} {}' relaxed from {} to {}, as the solver found no "
+                "solution otherwise.".format(
+                    type(constraint).__name__, constraint.level.factor.name,
+                    constraint.level.name, written, constraint.k))
+            return result
+    constraint.k = written
+    return result
+
+
+def _no_sequences_message(block, outcome) -> str:
+    """Why nothing came back, taken from the solver's answer rather than
+    inferred from the empty list."""
+    from sweetpea._internal.constraint import _KInARow
+    if outcome is SolveOutcome.UNKNOWN:
+        return ("No trial sequences found: the solver gave no answer, so this "
+                "reports a solver failure rather than the design.")
+    relaxed = solver_relaxable(block)
+    if relaxed is not None:
+        return ("No trial sequences found: the design has no solution, and "
+                "weakening {} by up to {} was not enough."
+                .format(type(relaxed).__name__, relaxed.relaxation.by))
+    cacs = [ct for ct in block.orig_constraints if isinstance(ct, CoverAllCombinations)]
+    if not cacs:
+        return "No trial sequences found: the design has no solution."
+    # Coverage auto-sizing cannot account for ordering constraints or
+    # LatinSquare, so name those as the likely conflict.
+    msg = ("No trial sequences found: the constraints could not be satisfied "
+           "together with " + " and ".join(repr(ct) for ct in cacs) + ".")
+    unmodeled = sorted(set(type(ct).__name__ for ct in block.orig_constraints
+                           if isinstance(ct, (_KInARow, LatinSquare))))
+    if unmodeled:
+        msg += (" Constraints of kind " + ", ".join(unmodeled)
+                + " are not folded into coverage auto-sizing; a MinimumTrials"
+                  " constraint can provide additional trials.")
+    return msg
 
 def sample_mismatch_experiment(block: Block, sample: dict) -> dict:
     """Given an experiment described with a :class:`.Block`, tests if :class:`list`

--- a/sweetpea/_internal/sampling_strategy/base.py
+++ b/sweetpea/_internal/sampling_strategy/base.py
@@ -3,6 +3,7 @@ from typing import List, cast
 from itertools import repeat
 
 from sweetpea._internal.block import Block
+from sweetpea._internal.core import SolveOutcome
 from sweetpea._internal.iter import intersperse
 
 
@@ -10,9 +11,13 @@ from sweetpea._internal.iter import intersperse
 Data object for sampling result.
 """
 class SamplingResult:
-    def __init__(self, samples: List[dict], metrics: dict) -> None:
+    def __init__(self, samples: List[dict], metrics: dict,
+                 outcome: SolveOutcome = SolveOutcome.UNKNOWN) -> None:
         self.samples = samples
         self.metrics = metrics
+        # Why `samples` is as short as it is. Strategies that cannot tell leave
+        # this UNKNOWN, which never triggers a fallback.
+        self.outcome = outcome
 
 """
 Generic interface for sampling strategies.

--- a/sweetpea/_internal/sampling_strategy/iterate_sat.py
+++ b/sweetpea/_internal/sampling_strategy/iterate_sat.py
@@ -2,7 +2,7 @@ from typing import List, cast
 
 from sweetpea._internal.sampling_strategy.base import Gen, SamplingResult
 from sweetpea._internal.block import Block
-from sweetpea._internal.core import CNF, sample_non_uniform
+from sweetpea._internal.core import CNF, SolveOutcome, sample_non_uniform
 
 """
 This represents a strategy where we "sample" just by using a SAT
@@ -20,12 +20,12 @@ class IterateSATGen(Gen):
         if block.show_errors():
             return SamplingResult([], {})
 
-        solutions = sample_non_uniform(sample_count,
+        (solutions, outcome) = sample_non_uniform(sample_count,
                                        CNF(backend_request.get_cnfs_as_json()),
                                        backend_request.fresh - 1,
                                        block.variables_per_sample(),
                                        backend_request.get_requests_as_generation_requests())
 
         result = list(map(lambda s: Gen.decode(block, s.assignment), solutions))
-        return SamplingResult(result, {})
+        return SamplingResult(result, {}, outcome)
 

--- a/sweetpea/_internal/sampling_strategy/random.py
+++ b/sweetpea/_internal/sampling_strategy/random.py
@@ -8,6 +8,7 @@ from math import factorial, ceil
 from typing import List, cast, Tuple, Dict, Optional, Union, Any
 
 from sweetpea._internal.block import Block
+from sweetpea._internal.core import SolveOutcome
 from sweetpea._internal.cross_block import CrossBlock
 from sweetpea._internal.combinatorics import (
     n_choose_m,
@@ -66,7 +67,9 @@ class RandomGen(Gen):
         metrics['solution_count'] = enumerator.solution_count()
 
         if (enumerator.solution_count() == 0):
-            return SamplingResult([], metrics)
+            # Exact enumeration, so this is a definitive answer about the design
+            # rather than a sampling run that came up empty.
+            return SamplingResult([], metrics, SolveOutcome.UNSATISFIABLE)
 
         crossing_size = enumerator.crossing_size # includes crossing weight
 
@@ -125,7 +128,7 @@ class RandomGen(Gen):
         if (total_rejected > 10000):
             print("")
 
-        return SamplingResult(samples, metrics)
+        return SamplingResult(samples, metrics, SolveOutcome.SATISFIED)
 
     @staticmethod
     def __are_constraints_violated(block: CrossBlock, sample: dict, enumerator: 'UCSolutionEnumerator',


### PR DESCRIPTION
Note: This carries the previous coverage commits from PR #87 that was closed

What it adds:

1) CoverAllCombinations now lets a design with no solution drop full coverage for optional factors, while reporting everything along the way. Coverage requires every combination up front, optional factors included; only when the solver reports no solution are they given up, last in the list first. A given-up factor still requires each of its levels to appear at least once.

2) `Relax(constraint, by)` — authorizes one constraint per experiment to be weakened by up to by steps toward its weaker form. Supports `ExactlyK`, `AtMostKInARow` and `AtLeastKInARow`.

`Relax(ExactlyK(3, (word, 'red')), by=1)`

An `ExactlyK` is repaired before the solver runs, since coverage sizing already computes the exact count a level needs. The in-a-row pair has no such model, so those are stepped only after the solver reports the design unsatisfiable.

`synthesize_trials` previously inferred failure from an empty list, unable to tell "unsatisfiable" from "sampler exhausted" from "solver crashed". Now produces a real UNSAT signal. 

Minor: Reworded a couple of passages in the documentation as discussed with MFlatt.